### PR TITLE
fix: UIResizeBorder to direction Top and Left

### DIFF
--- a/modules/corelib/ui/uiresizeborder.lua
+++ b/modules/corelib/ui/uiresizeborder.lua
@@ -56,10 +56,20 @@ function UIResizeBorder:onMouseMove(mousePos, mouseMoved)
         if self.vertical then
             local delta = mousePos.y - self:getY() - self:getHeight() / 2
             newSize = math.min(math.max(parent:getHeight() + delta, self.minimum), self.maximum)
+            if self:getAnchorType(AnchorBottom) ~= AnchorNone then
+              newSize = math.min(math.max(parent:getHeight() + delta, self.minimum), self.maximum)
+            elseif self:getAnchorType(AnchorTop) ~= AnchorNone then
+              newSize = math.min(math.max(parent:getHeight() - delta, self.minimum), self.maximum)
+            end
             parent:setHeight(newSize)
         else
             local delta = mousePos.x - self:getX() - self:getWidth() / 2
             newSize = math.min(math.max(parent:getWidth() + delta, self.minimum), self.maximum)
+            if self:getAnchorType(AnchorRight) ~= AnchorNone then
+              newSize = math.min(math.max(parent:getWidth() + delta, self.minimum), self.maximum)
+            elseif self:getAnchorType(AnchorLeft) ~= AnchorNone then
+              newSize = math.min(math.max(parent:getWidth() - delta, self.minimum), self.maximum)
+            end
             parent:setWidth(newSize)
         end
 


### PR DESCRIPTION
Note in video 1 that ResizeBorder works for Right and Bottom, but does not work for Top and Left. They all follow the same pattern of anchoring the parent on the side opposite to the ResizeBorder. In video 2, with this correction, ResizeBorder works correctly for all sides.


https://github.com/user-attachments/assets/a4354770-e4cd-424b-b8a3-74b5b0f74c87


https://github.com/user-attachments/assets/af95a66f-41f5-44ab-8c97-f3e43d1d9e7d

