### PR TITLE
fix: Prevent crash textedit

### DIFF
--- a/src/framework/ui/uitextedit.cpp
+++ b/src/framework/ui/uitextedit.cpp
@@ -592,7 +592,7 @@ void UITextEdit::moveCursorVertically(bool)
 
 int UITextEdit::getTextPos(const Point& pos)
 {
-    const int textLength = m_text.length();
+    const int textLength = std::min<int>(m_glyphsCoords.size(), m_text.length());
 
     // find any glyph that is actually on the
     int candidatePos = -1;


### PR DESCRIPTION
# Description

Interacting with texts may crash the client.

## Behavior

### **Actual**

<img width="1887" height="1000" alt="image" src="https://github.com/user-attachments/assets/c8792fa4-6474-40e0-b58f-e805d6ee0eca" />
<img width="402" height="676" alt="image" src="https://github.com/user-attachments/assets/d8b07dc1-a8ee-4ce2-96e5-1cd1f51dae87" />


### **Expected**

to not crash

## Fixes

\# (issue)

## Type of change

Please delete options that are not relevant.

  - [X] Bug fix (non-breaking change which fixes an issue)
  - [ ] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [ ] This change requires a documentation update

## How Has This Been Tested

Just keep interacting with random texts in terminal / chat until it crashes.

## Checklist

  - [ ] My code follows the style guidelines of this project
  - [ ] I have performed a self-review of my own code
  - [ ] I checked the PR checks reports
  - [ ] I have commented my code, particularly in hard-to-understand areas
  - [ ] I have made corresponding changes to the documentation
  - [ ] My changes generate no new warnings
  - [ ] I have added tests that prove my fix is effective or that my feature works
