### PR TITLE
fixes GM /hide command not able to walk with WASD or arrow keys stated in issue #155

### DIFF
--- a/src/client/creature.h
+++ b/src/client/creature.h
@@ -154,7 +154,7 @@ public:
 
     bool isRemoved() { return m_removed; }
     bool isInvisible() { return m_outfit.isEffect() && m_outfit.getAuxId() == 13; }
-    bool isDead() { return m_healthPercent <= 0; }
+    virtual bool isDead() { return m_healthPercent <= 0; }
     bool isFullHealth() { return m_healthPercent == 100; }
     bool canBeSeen() { return !isInvisible() || isPlayer(); }
     bool isCreature() override { return true; }

--- a/src/client/localplayer.h
+++ b/src/client/localplayer.h
@@ -125,6 +125,7 @@ public:
 
     LocalPlayerPtr asLocalPlayer() { return static_self_cast<LocalPlayer>(); }
     bool isLocalPlayer() override { return true; }
+    bool isDead() const { return m_health <= 0; }
 
     void onPositionChange(const Position& newPos, const Position& oldPos) override;
 


### PR DESCRIPTION
https://github.com/mehah/otclient/issues/155

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Behavior

### **Actual**

when using /hide command, player no longer able to walk due to blocking function isDead check on 

localplayer.cpp >
```
bool LocalPlayer::canWalk(const bool ignoreLock)
{
    // Prevent movement if the player is dead
    if (isDead())
        return false;
```


creature.h > isDead()

### **Expected**

using /hide command should allow GM to walk freely

## Fixes

\# (155)

## Type of change

Please delete options that are not relevant.

  - [ ] Bug fix (non-breaking change which fixes an issue)
  - [ ] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [ ] This change requires a documentation update

## How Has This Been Tested

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

  - [ ] Test A
  - [ ] Test B

**Test Configuration**:

  - Server Version:
  - Client:
  - Operating System:

## Checklist

  - [ ] My code follows the style guidelines of this project
  - [ ] I have performed a self-review of my own code
  - [ ] I checked the PR checks reports
  - [ ] I have commented my code, particularly in hard-to-understand areas
  - [ ] I have made corresponding changes to the documentation
  - [ ] My changes generate no new warnings
  - [ ] I have added tests that prove my fix is effective or that my feature works
