### PR TITLE
fix: Remove "test sleep" from HTTP login

### DIFF
--- a/src/framework/core/eventdispatcher.h
+++ b/src/framework/core/eventdispatcher.h
@@ -101,7 +101,7 @@ private:
         ADDED,
         MERGING,
         MERGED,
-    };;
+    };
 
     // Thread Events
     struct ThreadTask

--- a/src/framework/net/httplogin.cpp
+++ b/src/framework/net/httplogin.cpp
@@ -292,8 +292,6 @@ bool LoginHttp::parseJsonResponse(const std::string& body) {
     if (cancelled.load()) return false;
     json responseJson;
     try {
-        //Force reproduce #1034 issue. Remove after finish tests
-        std::this_thread::sleep_for(std::chrono::seconds(5));
         if (cancelled.load()) return false;
         responseJson = json::parse(body);
     } catch (...) {


### PR DESCRIPTION
<img width="734" height="195" alt="image" src="https://github.com/user-attachments/assets/6a243597-b8b0-4b6a-bc5d-2b938a7e3b1b" />
