### PR TITLE
fix: expand player state to 64-bit integer

### DIFF
--- a/modules/game_interface/widgets/statsbar.lua
+++ b/modules/game_interface/widgets/statsbar.lua
@@ -323,17 +323,9 @@ function StatsBar.reloadCurrentStatsBarQuickInfo_state(localPlayer, now, old)
     if now == old then
         return
     end
-    local bitsChanged = bit.bxor(now, old)
-    for i = 1, 32 do
-        local pow = math.pow(2, i - 1)
-        if pow > bitsChanged then
-            break
-        end
-        local bitChanged = bit.band(bitsChanged, pow)
-        if bitChanged ~= 0 then
-            toggleIcon(bitChanged)
-        end
-    end
+    Player.iterateChangedStates(now, old, function(bitChanged)
+        toggleIcon(bitChanged)
+    end)
 end
 
 function StatsBar.reloadCurrentStatsBarDeepInfo()

--- a/modules/game_skills/skills.lua
+++ b/modules/game_skills/skills.lua
@@ -1042,7 +1042,7 @@ local function getExperienceTooltip(localPlayer)
     end
     
     local states = localPlayer:getStates()
-    local isInBattle = bit.band(states, PlayerStates.Swords) > 0 or bit.band(states, PlayerStates.RedSwords) > 0
+    local isInBattle = Player.isStateActive(states, PlayerStates.Swords) or Player.isStateActive(states, PlayerStates.RedSwords)
     
     if not isInBattle then
         return tr('%s XP for next level', comma_value(expNeeded))

--- a/src/client/const.h
+++ b/src/client/const.h
@@ -268,7 +268,7 @@ namespace Otc
         NpcIconTradeQuest
     };
 
-    enum PlayerStates : uint32_t
+    enum PlayerStates : uint64_t
     {
         IconNone = 0,
         IconPoison = 1,

--- a/src/client/localplayer.cpp
+++ b/src/client/localplayer.cpp
@@ -242,12 +242,12 @@ void LocalPlayer::onPositionChange(const Position& newPos, const Position& oldPo
     m_serverWalk = false;
 }
 
-void LocalPlayer::setStates(const uint32_t states)
+void LocalPlayer::setStates(const uint64_t states)
 {
     if (m_states == states)
         return;
 
-    const uint32_t oldStates = m_states;
+    const uint64_t oldStates = m_states;
     m_states = states;
 
     if (isParalyzed())

--- a/src/client/localplayer.h
+++ b/src/client/localplayer.h
@@ -36,7 +36,7 @@ public:
     bool autoWalk(const Position& destination, bool retry = false);
     bool canWalk(bool ignoreLock = false);
 
-    void setStates(uint32_t states);
+    void setStates(uint64_t states);
     void setSkill(Otc::Skill skillId, uint16_t level, uint16_t levelPercent);
     void setBaseSkill(Otc::Skill skill, uint16_t baseLevel);
     void setHealth(uint32_t health, uint32_t maxHealth);
@@ -90,7 +90,7 @@ public:
     uint16_t getOfflineTrainingTime() { return m_offlineTrainingTime; }
     uint16_t getStoreExpBoostTime() { return m_storeExpBoostTime; }
 
-    uint32_t getStates() { return m_states; }
+    auto getStates() { return m_states; }
     uint32_t getMana() { return m_mana; }
     uint32_t getMaxMana() { return m_maxMana; }
     uint32_t getHealth() { return m_health; }
@@ -178,7 +178,7 @@ private:
 
     uint8_t m_autoWalkRetries{ 0 };
 
-    uint32_t m_states{ 0 };
+    uint64_t m_states{ 0 };
     uint8_t m_vocation{ 0 };
     uint16_t m_blessings{ Otc::BlessingNone };
 

--- a/src/client/protocolgameparse.cpp
+++ b/src/client/protocolgameparse.cpp
@@ -2493,7 +2493,7 @@ void ProtocolGame::parsePlayerSkills(const InputMessagePtr& msg) const
 
 void ProtocolGame::parsePlayerState(const InputMessagePtr& msg) const
 {
-    uint32_t states;
+    uint64_t states;
     if (g_game.getClientVersion() >= 1281) {
         states = g_game.getClientVersion() >= 1405 ? msg->getU64() : msg->getU32();
         if (g_game.getFeature(Otc::GamePlayerStateCounter)) {

--- a/src/framework/ui/uiwidgethtml.cpp
+++ b/src/framework/ui/uiwidgethtml.cpp
@@ -1171,7 +1171,7 @@ void UIWidget::updateTableLayout()
 
             UIWidget* cell = info.widget;
             const int padY = cell->getPaddingTop() + cell->getPaddingBottom();
-            const int contentH = std::max(0, tallestInRow - padY);
+            const int contentH = std::max<int>(0, tallestInRow - padY);
 
             if (cell->m_height.unit == Unit::Auto || cell->m_height.unit == Unit::FitContent) {
                 cell->setHeight_px(contentH);


### PR DESCRIPTION
Changed player state variables and related methods from uint32_t to uint64_t to support additional state flags for newer client versions. Also updated protocol parsing and getter/setter signatures accordingly. Minor fix in UIWidget HTML layout to use std::max<int> for clarity and fix compilation error on Visual Studio.