### PR TITLE
fix: bosstiary for client 13.10 (TFS)

### DIFF
--- a/modules/game_cyclopedia/tab/bosstiary/bosstiary.lua
+++ b/modules/game_cyclopedia/tab/bosstiary/bosstiary.lua
@@ -142,17 +142,21 @@ function Cyclopedia.CreateBosstiaryCreature(data)
     widget.ProgressValue:setText(data.kills)
 
     Cyclopedia.SetBestiaryProgress(46,widget.ProgressBack, widget.ProgressBack33, widget.ProgressBack55,  data.kills, CONFIG[data.category].PROWESS, CONFIG[data.category].EXPERTISE, CONFIG[data.category].MASTERY)
-   
+
     widget.Sprite:setOutfit(raceData.outfit)
     widget.Sprite:getCreature():setStaticWalking(1000)
     if data.unlocked then
         widget.Sprite:getCreature():setShader("")
         widget:setText(format(data.name))
-        widget.TrackCheck:enable()
-        if data.isTrackerActived == 1 then
-            widget.TrackCheck:setChecked(true)
+        if g_game.getClientVersion() >= 1320 then
+            widget.TrackCheck:enable()
+            if data.isTrackerActived == 1 then
+                widget.TrackCheck:setChecked(true)
+            else
+                widget.TrackCheck:setChecked(false)
+            end
         else
-            widget.TrackCheck:setChecked(false)
+            widget.TrackCheck:hide()
         end
     else
         widget.Sprite:getCreature():setShader("Outfit - cyclopedia-black")

--- a/src/client/protocolgameparse.cpp
+++ b/src/client/protocolgameparse.cpp
@@ -1560,7 +1560,9 @@ void ProtocolGame::parseBosstiaryInfo(const InputMessagePtr& msg)
         boss.category = msg->getU8();
         boss.kills = msg->getU32();
         msg->getU8();
-        boss.isTrackerActived = msg->getU8();
+        if (g_game.getClientVersion() >= 1320) {
+            boss.isTrackerActived = msg->getU8();
+        }
         bossData.emplace_back(boss);
     }
 


### PR DESCRIPTION
# Description

Disable tracking checkbox for client version <13.20
OTC
<img width="1022" height="676" alt="image" src="https://github.com/user-attachments/assets/b7d85c88-7e54-4e3e-a45a-c58bfdfb4376" />
Cipsoft
<img width="1021" height="681" alt="image" src="https://github.com/user-attachments/assets/9c2a5a91-d781-4eb1-a39b-ca46ce3b144c" />


## Behavior

Fail to parse package that comes for 13.10 client

### **Expected**

List of bosses

## Fixes

N/A

## Type of change

Please delete options that are not relevant.

  - [x] Bug fix (non-breaking change which fixes an issue)
  - [ ] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [ ] This change requires a documentation update

## How Has This Been Tested

1) Prepare TFS 13.10 and use code from this branch https://github.com/otland/forgottenserver/pull/4868
2) run OTC
3) open Bosstiary tab in cycopedia

**Test Configuration**:

  - Server Version: 13.10
  - Client: 13.10
  - Operating System:

## Checklist

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [x] I checked the PR checks reports
  - [x] I have commented my code, particularly in hard-to-understand areas
  - [x] I have made corresponding changes to the documentation
  - [x] My changes generate no new warnings
  - [x] I have added tests that prove my fix is effective or that my feature works
