### PR TITLE
fix: spell name tooltips in the cooldowns window

### DIFF
--- a/modules/game_cooldown/cooldown.lua
+++ b/modules/game_cooldown/cooldown.lua
@@ -56,17 +56,17 @@ function loadIcon(iconId)
     local spell, profile, spellName = Spells.getSpellByIcon(iconId)
     if not spellName then
         print('[WARNING] loadIcon: empty spellName for tfs spell id: ' .. iconId)
-        return
+        return nil, nil
     end
     if not profile then
         print('[WARNING] loadIcon: empty profile for tfs spell id: ' .. iconId)
-        return
+        return nil, nil
     end
 
     clientIconId = Spells.getClientId(spellName)
     if not clientIconId then
         print('[WARNING] loadIcon: empty clientIconId for tfs spell id: ' .. iconId)
-        return
+        return nil, nil
     end
 
     local icon = cooldownPanel:getChildById(iconId)
@@ -83,7 +83,7 @@ function loadIcon(iconId)
         print('[WARNING] loadIcon: empty spell icon for tfs spell id: ' .. iconId)
         icon = nil
     end
-    return icon
+    return icon, spellName
 end
 
 function onMiniWindowOpen()
@@ -188,7 +188,7 @@ function onSpellCooldown(iconId, duration)
     if not cooldownWindow:isVisible() then
         return
     end
-    local icon = loadIcon(iconId)
+    local icon, spellName = loadIcon(iconId)
     if not icon then
         print('[WARNING] Can not load cooldown icon on spell with id: ' .. iconId)
         return


### PR DESCRIPTION
# Description

The code for the window from the `game_cooldown` module includes an apparent tooltip showing the spell name, but as of now it's always set to nil (`progressRect:setTooltip(spellName)` -> `spellName` is never defined).

## Behavior

### **Actual**

No tooltip shows over the cooldown icons of individual spells.

### **Expected**

A tooltip shows the spell name when hovering 

## Type of change

Please delete options that are not relevant.

  - [x] Bug fix (non-breaking change which fixes an issue)
  - [ ] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [ ] This change requires a documentation update

## How Has This Been Tested

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

  - [x] On any client version above 8.70, cast a spell, open the cooldown window, hover the mouse above the spell's individual cooldown.

**Test Configuration**:

  - Server Version: Any
  - Client: 8.70+
  - Operating System: Any

## Checklist

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [x] I checked the PR checks reports
  - [x] I have commented my code, particularly in hard-to-understand areas
  - [x] I have made corresponding changes to the documentation
  - [x] My changes generate no new warnings
  - [x] I have added tests that prove my fix is effective or that my feature works
