### PR TITLE
Fix nested for loop context inheritance

### DIFF
--- a/modules/corelib/ui/uiwidget.lua
+++ b/modules/corelib/ui/uiwidget.lua
@@ -530,20 +530,25 @@ function UIWidget:__childFor(moduleName, expr, html, index)
         local widget = self.widget
 
         local function merge_parent_for_env(base, w)
-            if not w.__for_keys or not w.__for_values then return base end
-            local names = {}
-            for name in string.gmatch(w.__for_keys, "[^,%s]+") do
-                if name ~= "" then
-                    names[#names + 1] = name
+            while w do
+                if w.__for_keys and w.__for_values then
+                    local names = {}
+                    for name in string.gmatch(w.__for_keys, "[^,%s]+") do
+                        if name ~= "" then
+                            names[#names + 1] = name
+                        end
+                    end
+                    local e = {}
+                    local maxn = math.min(#names, #w.__for_values)
+                    for i = 1, maxn do
+                        e[names[i]] = w.__for_values[i]
+                    end
+                    setmetatable(e, { __index = base })
+                    base = e
                 end
+                w = w:getParent()
             end
-            local e = {}
-            local maxn = math.min(#names, #w.__for_values)
-            for i = 1, maxn do
-                e[names[i]] = w.__for_values[i]
-            end
-            setmetatable(e, { __index = base })
-            return e
+            return base
         end
 
         local env = merge_parent_for_env(baseEnv, widget)


### PR DESCRIPTION
# Description

Fixed an issue where nested `*for` directives inside parent loops would lose access to outer loop variables in the UI template engine.  

This bug occurred when a child element tried to access variables from the parent `*for` scope — the environment for the child widget was not inheriting the parent’s loop variables, causing `slot` (or other outer-scope variables) to become `nil` inside nested loops.

The fix updates `merge_parent_for_env` in `modules/corelib/ui/uiwidget.lua` to correctly walk through ancestor widgets and merge their `__for_keys` and `__for_values` into the current scope, preserving nested variable access.

---

## Behavior

### **Actual**

When using nested `*for` directives, inner templates lose access to variables from the outer loop.  
Example:
```html
<div
  *for="local slot in (self.preyData or {})"
>
  <div
    *for="local race in (self.raceList or {})"
    *if="race.raceId <= 20"
  >
    {{slot.slotid}} <!-- slot becomes nil here -->
  </div>
</div>
```

### **Expected**

Inner templates should inherit and have access to variables from the parent `*for` environment.  
In the example above, `{{slot.slotid}}` should correctly display the parent loop’s `slot` data.

---

## Fixes

Enhances `merge_parent_for_env` to recursively collect parent loop environments so that nested `*for` directives inherit outer variables.

---

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

---

## How Has This Been Tested

Verified using nested `*for` loops in the `prey` interface:

- Rendered a parent slot list (`self.preyData`)
- Nested monster names list (`self.raceList`)
- Confirmed that `{{slot.slotid}}` now renders correctly within the inner loop.

**Test Configuration:**
- Server Version: Canary latest
- Client: OTClient custom fork
- Operating System: Windows 10

---

## Checklist

- [x] My code follows the style guidelines of this project  
- [x] I have performed a self-review of my own code  
- [x] I checked the PR checks reports  




