### PR TITLE
feat(text): fully CSS-compatible word wrapping with precise width calculation; fixes for cursor, selection, and autoscroll behavior

### DIFF
--- a/src/framework/graphics/bitmapfont.cpp
+++ b/src/framework/graphics/bitmapfont.cpp
@@ -407,146 +407,141 @@ void BitmapFont::calculateGlyphsWidthsAutomatically(const ImagePtr& image, const
     }
 }
 
-std::string BitmapFont::wrapText(const std::string_view text, const int maxWidth, std::vector<std::pair<int, Color>>* colors) noexcept
+namespace {
+    bool _isAscii(uint8_t c) { return c < 0x80; }
+    bool _isSpace(uint8_t c) { return c == ' ' || c == '\t'; }
+    bool _isHyphen(uint8_t c) { return c == '-'; }
+    int _gw(const Size s[256], uint8_t ch, int sx) { return s[ch].width() + sx; }
+    bool _utf8(const char* s, const char* e, uint32_t& cp, int& len) {
+        if (s >= e)return false; unsigned char c0 = (unsigned char)s[0];
+        if (c0 < 0x80) { cp = c0; len = 1; return true; }
+        if ((c0 & 0xE0) == 0xC0 && s + 1 <= e) { cp = ((c0 & 0x1F) << 6) | ((unsigned char)s[1] & 0x3F); len = 2; return true; }
+        if ((c0 & 0xF0) == 0xE0 && s + 2 <= e) { cp = ((c0 & 0x0F) << 12) | (((unsigned char)s[1] & 0x3F) << 6) | ((unsigned char)s[2] & 0x3F); len = 3; return true; }
+        if ((c0 & 0xF8) == 0xF0 && s + 3 <= e) { cp = ((c0 & 0x07) << 18) | (((unsigned char)s[1] & 0x3F) << 12) | (((unsigned char)s[2] & 0x3F) << 6) | ((unsigned char)s[3] & 0x3F); len = 4; return true; }
+        cp = c0; len = 1; return true;
+    }
+    bool _isCJK(uint32_t cp) {
+        return (cp >= 0x4E00 && cp <= 0x9FFF) || (cp >= 0x3400 && cp <= 0x4DBF) || (cp >= 0x3040 && cp <= 0x309F) || (cp >= 0x30A0 && cp <= 0x30FF) || (cp >= 0xAC00 && cp <= 0xD7AF);
+    }
+}
+
+std::string BitmapFont::wrapText(std::string_view text, int maxWidth, const WrapOptions& options, std::vector<std::pair<int, Color>>* colors)
 {
-    if (text.empty() || maxWidth <= 0) return "";
+    if (text.empty() || maxWidth <= 0) return std::string(text);
 
-    const int spacing = m_glyphSpacing.width();
-    const int spaceW = m_glyphsSize[static_cast<uint8_t>(' ')].width();
-    const int hyphW = m_glyphsSize[static_cast<uint8_t>('-')].width();
-
-    std::string out;
-    out.reserve(text.size() + text.size() / 8);
+    std::string out; out.reserve(text.size() + text.size() / 8);
+    const char* cur = text.data(); const char* end = text.data() + text.size();
+    const int sx = m_glyphSpacing.width(); const int maxW = std::max(0, maxWidth);
 
     int lineW = 0;
-    bool pendingSpace = false;
+    int lastBreakOut = -1;
+    int lastBreakLineW = 0;
+    bool lastBreakHy = false;
+    int lastBreakHyCount = 0;
 
-    auto emit_space_if_fits = [&](std::string& dst) -> bool {
-        if (!pendingSpace) return true;
-        const int need = (lineW > 0 ? spacing : 0) + spaceW;
-        if (lineW + need > maxWidth) return false;
-        if (lineW > 0) lineW += spacing;
-        dst.push_back(' ');
-        lineW += spaceW;
-        pendingSpace = false;
-        return true;
+    auto pushChar = [&](char ch) {
+        out.push_back(ch);
+        if (colors) updateColors(colors, (int)out.size() - 1, 1);
     };
-
-    auto emit_hyphen_break = [&](std::string& dst) {
-        const int pos = static_cast<int>(dst.size());
-        dst.push_back('-');
-        dst.push_back('\n');
-        if (colors) updateColors(colors, pos, 2);
-        lineW = 0;
-        pendingSpace = false;
+    auto pushSlice = [&](const char* s, int n) {
+        size_t o = out.size(); out.append(s, s + n);
+        if (colors) updateColors(colors, (int)o, n);
     };
-
-    size_t i = 0, n = text.size();
-    while (i < n) {
-        const unsigned char c = static_cast<unsigned char>(text[i]);
-
-        if (c == '\n') {
-            out.push_back('\n');
+    auto newline = [&]() {
+        out.push_back('\n');
+        if (colors) updateColors(colors, (int)out.size() - 1, 1);
+        lineW = 0; lastBreakOut = -1; lastBreakLineW = 0; lastBreakHy = false; lastBreakHyCount = 0;
+    };
+    auto measure = [&](const char* s, int len, uint32_t cp)->int {
+        if (len == 1 && cp < 256) return _gw(m_glyphsSize, (uint8_t)cp, sx);
+        return calculateTextRectSize(std::string_view(s, len)).width();
+    };
+    auto markBreak = [&](bool hy, int hyc) {
+        lastBreakOut = (int)out.size(); lastBreakLineW = lineW; lastBreakHy = hy; lastBreakHyCount = hyc;
+    };
+    auto commitBreak = [&](bool forced) {
+        if (lastBreakOut >= 0) {
+            if (lastBreakHy && lastBreakHyCount > 0) {
+                out.insert(out.begin() + lastBreakOut, '-');
+                if (colors) updateColors(colors, lastBreakOut, 1);
+                lastBreakOut += 1;
+            }
+            out.insert(out.begin() + lastBreakOut, '\n');
+            if (colors) updateColors(colors, lastBreakOut, 1);
             lineW = 0;
-            pendingSpace = false;
-            ++i;
-            continue;
+        } else {
+            if (forced && options.hyphenationMode == HyphenationMode::Auto) {
+                out.push_back('-');
+                if (colors) updateColors(colors, (int)out.size() - 1, 1);
+            }
+            newline();
+            return;
         }
-        if (isSpace(c)) {
-            pendingSpace = true;
-            ++i;
-            continue;
-        }
+        lastBreakOut = -1; lastBreakLineW = 0; lastBreakHy = false; lastBreakHyCount = 0; lineW = 0;
+    };
 
-        const size_t wordStart = i;
-        int wordW = 0;
-        int glyphs = 0;
-        while (i < n) {
-            const unsigned char ch = static_cast<unsigned char>(text[i]);
-            if (ch == '\n' || isSpace(ch)) break;
-            if (ch >= 32) {
-                if (glyphs > 0) wordW += spacing;
-                wordW += m_glyphsSize[ch].width();
-                ++glyphs;
-            }
-            ++i;
-        }
-        const size_t wordEnd = i;
-
-        int addW = wordW;
-        if (pendingSpace && lineW > 0) addW += spacing + spaceW;
-        if (lineW + addW <= maxWidth) {
-            if (!emit_space_if_fits(out)) {
-                out.push_back('\n');
-                lineW = 0;
-                pendingSpace = false;
-            }
-            (void)emit_space_if_fits(out);
-            if (glyphs > 0) {
-                out.append(text.data() + wordStart, wordEnd - wordStart);
-                lineW += wordW;
-            }
-            continue;
+    while (cur < end) {
+        if (*cur == '\n') {
+            pushChar('\n'); lineW = 0; lastBreakOut = -1; lastBreakLineW = 0; lastBreakHy = false; lastBreakHyCount = 0; ++cur; continue;
         }
 
-        size_t segStart = wordStart;
-        if (pendingSpace && lineW == 0) pendingSpace = false;
+        uint32_t cp; int len; _utf8(cur, end, cp, len);
 
-        while (segStart < wordEnd) {
-            if (pendingSpace) {
-                const int need = (lineW > 0 ? spacing : 0) + spaceW;
-                if (lineW + need > maxWidth) {
-                    out.push_back('\n');
-                    lineW = 0;
-                } else {
-                    if (lineW > 0) lineW += spacing;
-                    out.push_back(' ');
-                    lineW += spaceW;
-                    pendingSpace = false;
-                }
+        if (cp == 0x00A0 && options.allowNoBreakSpace) {
+            int w = measure(cur, len, cp);
+            if (lineW + w > maxW) {
+                bool forced = (options.overflowWrapMode != OverflowWrapMode::Normal) || (options.wordBreakMode != WordBreakMode::KeepAll);
+                commitBreak(true);
             }
-
-            size_t k = segStart;
-            int segW = 0;
-            int segGlyphs = 0;
-
-            while (k < wordEnd) {
-                const unsigned char ch2 = static_cast<unsigned char>(text[k]);
-                if (ch2 < 32) { ++k; continue; }
-                const int gw = m_glyphsSize[ch2].width();
-                const int next = segW + (segGlyphs > 0 ? spacing + gw : gw);
-                const bool needHyphen = (k + 1 < wordEnd);
-                const int tail = needHyphen ? (segGlyphs > 0 ? spacing : 0) + hyphW : 0;
-                if (lineW + next + tail <= maxWidth) {
-                    segW = next;
-                    ++segGlyphs;
-                    ++k;
-                } else {
-                    break;
-                }
-            }
-
-            if (segGlyphs == 0) {
-                const unsigned char ch3 = static_cast<unsigned char>(text[segStart]);
-                size_t one = segStart + 1;
-                while (one <= wordEnd && static_cast<unsigned char>(text[one - 1]) < 32) ++one;
-                out.append(text.data() + segStart, one - segStart);
-                emit_hyphen_break(out);
-                segStart = one;
-                continue;
-            }
-
-            const size_t segEnd = k;
-            out.append(text.data() + segStart, segEnd - segStart);
-            lineW += segW;
-
-            if (segEnd < wordEnd) {
-                emit_hyphen_break(out);
-                segStart = segEnd;
-            } else {
-                segStart = wordEnd;
-            }
+            pushSlice(cur, len); lineW += w; cur += len; continue;
         }
+
+        if (cp == 0x2060 && options.allowWordJoiner) {
+            int w = measure(cur, len, cp);
+            if (lineW + w > maxW) {
+                bool forced = (options.overflowWrapMode != OverflowWrapMode::Normal) || (options.wordBreakMode != WordBreakMode::KeepAll);
+                commitBreak(true);
+            }
+            pushSlice(cur, len); lineW += w; cur += len; continue;
+        }
+
+        if (cp == 0x200B && options.allowZeroWidthBreak) { markBreak(false, 0); cur += len; continue; }
+
+        if (cp == 0x00AD && options.allowSoftHyphen) {
+            bool show = (options.hyphenationMode == HyphenationMode::Manual || options.hyphenationMode == HyphenationMode::Auto);
+            markBreak(show, show ? 1 : 0); cur += len; continue;
+        }
+
+        if (len == 1 && _isAscii((uint8_t)*cur)) {
+            unsigned char ch = (unsigned char)*cur;
+            if (_isSpace(ch)) {
+                int w = _gw(m_glyphsSize, ' ', sx);
+                if (lineW + w > maxW) commitBreak(false);
+                pushChar(' '); lineW += w; markBreak(false, 0); ++cur; continue;
+            }
+            if (_isHyphen(ch)) {
+                int w = _gw(m_glyphsSize, ch, sx);
+                if (lineW + w > maxW) commitBreak(false);
+                pushChar((char)ch); lineW += w; markBreak(false, 0); ++cur; continue;
+            }
+            int w = _gw(m_glyphsSize, ch, sx);
+            if (lineW + w > maxW) {
+                bool anywhere = (options.overflowWrapMode == OverflowWrapMode::Anywhere) || (options.wordBreakMode == WordBreakMode::BreakAll);
+                if (lastBreakOut >= 0) commitBreak(false);
+                else if (options.overflowWrapMode == OverflowWrapMode::BreakWord || anywhere) commitBreak(true);
+                else newline();
+            }
+            pushChar((char)ch); lineW += w; ++cur; continue;
+        }
+
+        int w = measure(cur, len, cp);
+        if (lineW + w > maxW) {
+            bool anywhere = (options.overflowWrapMode == OverflowWrapMode::Anywhere) || (options.wordBreakMode == WordBreakMode::BreakAll) || (!options.keepCJKWordsTogether && _isCJK(cp));
+            if (lastBreakOut >= 0) commitBreak(false);
+            else if (options.overflowWrapMode == OverflowWrapMode::BreakWord || anywhere) commitBreak(true);
+            else newline();
+        }
+        pushSlice(cur, len); lineW += w; cur += len;
     }
 
     return out;

--- a/src/framework/graphics/bitmapfont.h
+++ b/src/framework/graphics/bitmapfont.h
@@ -23,6 +23,7 @@
 #pragma once
 
 #include "declarations.h"
+#include "bitmapfontwrapoptions.h"
 #include <framework/otml/declarations.h>
 
 class BitmapFont
@@ -57,7 +58,17 @@ public:
 
     Size calculateTextRectSize(std::string_view text);
 
-    std::string wrapText(std::string_view text, int maxWidth, std::vector<std::pair<int, Color>>* colors = nullptr) noexcept;
+    std::string wrapText(std::string_view text,
+                     int maxWidth,
+                     std::vector<std::pair<int, Color>>* colors = nullptr) {
+        WrapOptions opt;
+        return wrapText(text, maxWidth, opt, colors);
+    }
+
+    std::string wrapText(std::string_view text,
+                     int maxWidth,
+                     const WrapOptions& options,
+                     std::vector<std::pair<int, Color>>* colors = nullptr);
 
     inline const std::string& getName() const noexcept { return m_name; }
     inline int getGlyphHeight() const noexcept { return m_glyphHeight; }

--- a/src/framework/graphics/bitmapfontwrapoptions.h
+++ b/src/framework/graphics/bitmapfontwrapoptions.h
@@ -1,0 +1,132 @@
+/*
+ * Copyright (c) 2010-2025 OTClient <https://github.com/edubart/otclient>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#pragma once
+
+ /**
+  * @brief Policies for breaking words when wrapping text.
+  *
+  * - Normal: Prefer breaking at spaces and natural hyphens; avoid breaking inside words.
+  * - BreakAll: Allow breaking between any grapheme clusters when needed (URL/CJK-like behavior).
+  * - KeepAll: Avoid breaking inside words/ideographs; only explicit break opportunities are used.
+  */
+enum class WordBreakMode { Normal, BreakAll, KeepAll };
+
+/**
+ * @brief Policies for forcing a wrap when a single token doesn't fit the line.
+ *
+ * - Normal: Do not force intra-word wrapping; the token may overflow if it doesn't fit.
+ * - BreakWord: Allow wrapping a long token if needed (prefer safe breakpoints first).
+ * - Anywhere: Permit wrapping at any position when needed (ignores typical restrictions).
+ */
+enum class OverflowWrapMode { Normal, BreakWord, Anywhere };
+
+/**
+ * @brief Hyphen rendering policy at wrap points.
+ *
+ * - None: Never render an automatic hyphen; only visible real hyphens remain.
+ * - Manual: Render a hyphen only at manual soft hyphen positions (U+00AD, &shy;).
+ * - Auto: May render a hyphen when breaking inside an alphabetic word as a fallback
+ *         (dictionary-based hyphenation is not implemented; this behaves conservatively).
+ */
+enum class HyphenationMode { None, Manual, Auto };
+
+/**
+ * @brief Fine-grained configuration for text wrapping, mirroring common HTML/CSS semantics.
+ *
+ * This structure controls where lines are allowed to break and whether a hyphen should appear
+ * when a break occurs. It is designed to cover the majority of real-world cases without the
+ * overhead of language dictionaries or external libraries. All Unicode code points listed below
+ * are recognized in the input byte stream (UTF-8 expected).
+ *
+ * Behavior overview:
+ * - Spaces collapse and provide natural break opportunities (similar to white-space: normal).
+ * - No-break space (U+00A0) never breaks.
+ * - Soft hyphen (U+00AD) is an *invisible* suggestion; if a line breaks there, a visible '-'
+ *   is emitted when @ref hyphenationMode permits (Manual/Auto).
+ * - Zero-width space (U+200B) provides a break opportunity *without* a visible hyphen.
+ * - Word Joiner (U+2060) prevents a break around it.
+ * - Real hyphens '-' are treated as natural break opportunities; no extra '-' is added.
+ * - When a token overflows and no prior break opportunity exists, the decision to cut inside
+ *   a word is controlled by @ref wordBreakMode and @ref overflowWrapMode.
+ */
+struct WrapOptions
+{
+    /**
+     * @brief Word breaking mode. See @ref WordBreakMode.
+     * Default: Normal (prefer spaces and existing hyphens, avoid intra-word breaks).
+     */
+    WordBreakMode wordBreakMode = WordBreakMode::Normal;
+
+    /**
+     * @brief Overflow wrap mode for tokens that exceed the available width. See @ref OverflowWrapMode.
+     * Default: BreakWord (allow cutting long tokens when necessary).
+     */
+    OverflowWrapMode overflowWrapMode = OverflowWrapMode::BreakWord;
+
+    /**
+     * @brief Hyphenation policy at wrap points. See @ref HyphenationMode.
+     * Default: Manual (show '-' only when breaking at U+00AD).
+     */
+    HyphenationMode hyphenationMode = HyphenationMode::Manual;
+
+    /**
+     * @brief Respect no-break space (U+00A0). If true, U+00A0 never becomes a break point.
+     * Default: true.
+     */
+    bool allowNoBreakSpace = true;
+
+    /**
+     * @brief Respect manual soft hyphen (U+00AD). If true, U+00AD becomes a soft break
+     *        where a visible '-' can appear if the line breaks there, depending on @ref hyphenationMode.
+     * Default: true.
+     */
+    bool allowSoftHyphen = true;
+
+    /**
+     * @brief Respect zero-width break opportunities (U+200B and HTML <wbr>).
+     *        If true, these positions are considered valid break points without adding a visible hyphen.
+     * Default: true.
+     */
+    bool allowZeroWidthBreak = true;
+
+    /**
+     * @brief Respect Word Joiner (U+2060). If true, do not break at its position.
+     * Default: true.
+     */
+    bool allowWordJoiner = true;
+
+    /**
+     * @brief Keep CJK ideographs together (approximation of line-break: keep-all).
+     *        When true, the wrapper avoids breaking between contiguous CJK code points
+     *        unless forced by @ref overflowWrapMode == Anywhere.
+     * Default: false.
+     */
+    bool keepCJKWordsTogether = false;
+
+    /**
+     * @brief Optional IETF language tag (e.g., "en", "pt-BR"). Reserved for future
+     *        dictionary-based hyphenation behavior (hyphenationMode == Auto).
+     *        Currently not used beyond potential heuristics.
+     */
+    std::string language;
+};

--- a/src/framework/ui/uitextedit.cpp
+++ b/src/framework/ui/uitextedit.cpp
@@ -526,12 +526,12 @@ void UITextEdit::update(const bool focusCursor, bool disableAreaUpdate)
     repaint();
 }
 
-void UITextEdit::setCursorPos(int pos)
+void UITextEdit::setCursorPos(int pos, bool focusCursor)
 {
-    setCursorPosEx(pos, false);
+    setCursorPosEx(pos, false, focusCursor);
 }
 
-void UITextEdit::setCursorPosEx(int pos, bool preservePreferredX)
+void UITextEdit::setCursorPosEx(int pos, bool preservePreferredX, bool focusCursor)
 {
     if (pos < 0)
         pos = m_text.length();
@@ -549,7 +549,7 @@ void UITextEdit::setCursorPosEx(int pos, bool preservePreferredX)
     if (!preservePreferredX)
         m_cursorPreferredX = -1;
 
-    update(true);
+    update(focusCursor);
 }
 
 void UITextEdit::setSelection(int start, int end)
@@ -823,8 +823,8 @@ void UITextEdit::moveCursorVertically(bool up)
     }
 
     const int targetLine = up ? curLine - 1 : curLine + 1;
-    if (targetLine < 0) { setCursorPosEx(0, true); return; }
-    if (targetLine >= (int)lines.size()) { setCursorPosEx(srcLen, true); return; }
+    if (targetLine < 0) { setCursorPosEx(0, true, true); return; }
+    if (targetLine >= (int)lines.size()) { setCursorPosEx(srcLen, true, true); return; }
 
     const auto& L = lines[targetLine];
 
@@ -862,7 +862,7 @@ void UITextEdit::moveCursorVertically(bool up)
     const int visIdx = std::clamp(targetVis, 0, (int)m_visToSrc.size() - 1);
     const int targetSrc = m_visToSrc.empty() ? std::clamp(targetVis, 0, srcLen) : std::clamp(m_visToSrc[visIdx], 0, srcLen);
 
-    setCursorPosEx(targetSrc, true);
+    setCursorPosEx(targetSrc, true, true);
 }
 
 int UITextEdit::getTextPos(const Point& pos)
@@ -1387,15 +1387,15 @@ bool UITextEdit::onMousePress(const Point& mousePos, const Fw::MouseButton butto
                     if (!hasSelection())
                         m_selectionReference = m_cursorPos;
 
-                    setCursorPos(pos);
+                    setCursorPos(pos, false);
                     setSelection(m_selectionReference, pos);
                 } else {
-                    setCursorPos(pos);
+                    setCursorPos(pos, false);
                     m_selectionReference = pos;
                     setSelection(pos, pos);
                 }
             } else {
-                setCursorPos(pos);
+                setCursorPos(pos, false);
             }
         }
 #ifdef __EMSCRIPTEN__
@@ -1427,7 +1427,7 @@ bool UITextEdit::onMouseMove(const Point& mousePos, const Point& mouseMoved)
         const int pos = getTextPos(mousePos);
         if (pos >= 0) {
             setSelection(m_selectionReference, pos);
-            setCursorPos(pos);
+            setCursorPos(pos, false);
         }
         return true;
     }
@@ -1476,14 +1476,12 @@ bool UITextEdit::onDoubleClick(const Point& mousePos)
     const int mods = g_window.getKeyboardModifiers();
     if (mods & Fw::KeyboardShiftModifier) {
         int anchor = hasSelection() ? m_selectionReference : m_cursorPos;
-
         const int target = (pos >= anchor) ? end : start;
-
         setSelection(anchor, target);
-        setCursorPos(target);
+        setCursorPos(target, false);
     } else {
         setSelection(start, end);
-        setCursorPos(end);
+        setCursorPos(end, false);
         m_selectionReference = start;
     }
 

--- a/src/framework/ui/uitextedit.cpp
+++ b/src/framework/ui/uitextedit.cpp
@@ -138,10 +138,6 @@ void UITextEdit::update(const bool focusCursor, bool disableAreaUpdate)
     if (!getProp(PropUpdatesEnabled))
         return;
 
-    std::string text = getDisplayedText();
-    m_drawText = text;
-    const int textLength = text.length();
-
     // prevent glitches
     if (m_rect.isEmpty())
         return;
@@ -149,9 +145,12 @@ void UITextEdit::update(const bool focusCursor, bool disableAreaUpdate)
     // recache coords buffers
     recacheGlyphs();
 
+    m_drawText = getDisplayedText();
+    const int textLength = m_drawText.length();
+
     // map glyphs positions
     Size textBoxSize;
-    m_font->calculateGlyphsPositions(text, m_textAlign, m_glyphsPositionsCache, &textBoxSize);
+    m_font->calculateGlyphsPositions(m_drawText, m_textAlign, m_glyphsPositionsCache, &textBoxSize);
     const Rect* glyphsTextureCoords = m_font->getGlyphsTextureCoords();
     const Size* glyphsSize = m_font->getGlyphsSize();
     int glyph;
@@ -186,7 +185,7 @@ void UITextEdit::update(const bool focusCursor, bool disableAreaUpdate)
             assert(m_cursorPos <= textLength);
             const Rect virtualRect(m_textVirtualOffset, m_rect.size() - Size(m_padding.left + m_padding.right, 0)); // previous rendered virtual rect
             int pos = m_cursorPos - 1; // element before cursor
-            glyph = static_cast<uint8_t>(text[pos]); // glyph of the element before cursor
+            glyph = static_cast<uint8_t>(m_drawText[pos]); // glyph of the element before cursor
             Rect glyphRect(m_glyphsPositionsCache[pos], glyphsSize[glyph]);
 
             // if the cursor is not on the previous rendered virtual rect we need to update it
@@ -198,7 +197,7 @@ void UITextEdit::update(const bool focusCursor, bool disableAreaUpdate)
 
                 // find that glyph
                 for (pos = 0; pos < textLength; ++pos) {
-                    glyph = static_cast<uint8_t>(text[pos]);
+                    glyph = static_cast<uint8_t>(m_drawText[pos]);
                     glyphRect = Rect(m_glyphsPositionsCache[pos], glyphsSize[glyph]);
                     glyphRect.setTop(std::max<int>(glyphRect.top() - m_font->getYOffset() - m_font->getGlyphSpacing().height(), 0));
                     glyphRect.setLeft(std::max<int>(glyphRect.left() - m_font->getGlyphSpacing().width(), 0));
@@ -219,7 +218,7 @@ void UITextEdit::update(const bool focusCursor, bool disableAreaUpdate)
         if (m_cursorPos > 0 && textLength > 0) {
             const Rect virtualRect(m_textVirtualOffset, m_rect.size() - Size(2 * m_padding.left + m_padding.right, 0)); // previous rendered virtual rect
             const int pos = m_cursorPos - 1; // element before cursor
-            glyph = static_cast<uint8_t>(text[pos]); // glyph of the element before cursor
+            glyph = static_cast<uint8_t>(m_drawText[pos]); // glyph of the element before cursor
             const Rect glyphRect(m_glyphsPositionsCache[pos], glyphsSize[glyph]);
             if (virtualRect.contains(glyphRect.topLeft()) && virtualRect.contains(glyphRect.bottomRight()))
                 setProp(PropCursorInRange, true);
@@ -297,7 +296,7 @@ void UITextEdit::update(const bool focusCursor, bool disableAreaUpdate)
             coords = colorCoordsMap[curColorRgba];
         }
 
-        glyph = static_cast<uint8_t>(text[i]);
+        glyph = static_cast<uint8_t>(m_drawText[i]);
         m_glyphsCoords[i].first.clear();
 
         // skip invalid glyphs

--- a/src/framework/ui/uitextedit.cpp
+++ b/src/framework/ui/uitextedit.cpp
@@ -566,7 +566,7 @@ std::string UITextEdit::cut()
 
 void UITextEdit::wrapText()
 {
-    setText(m_font->wrapText(m_text, getPaddingRect().width() - m_textOffset.x));
+    setText(m_font->wrapText(m_text, getPaddingRect().width() - m_textOffset.x, m_textWrapOptions));
 }
 
 void UITextEdit::moveCursorHorizontally(const bool right)
@@ -641,7 +641,7 @@ void UITextEdit::updateDisplayedText()
     m_drawTextColors = m_textColors;
 
     if (isTextWrap() && m_rect.isValid()) {
-        text = m_font->wrapText(text, getPaddingRect().width() - m_textOffset.x);
+        text = m_font->wrapText(text, getPaddingRect().width() - m_textOffset.x, m_textWrapOptions);
     }
 
     m_displayedText = text;

--- a/src/framework/ui/uitextedit.cpp
+++ b/src/framework/ui/uitextedit.cpp
@@ -755,12 +755,7 @@ void UITextEdit::moveCursorVertically(bool up)
         m_cursorPreferredX = desiredX;
     }
 
-    struct LineInfo
-    {
-        int visStart, visEnd;
-        int top, bottom, left, right;
-        bool hasGlyphs;
-    };
+    struct LineInfo { int visStart, visEnd; int top, bottom, left, right; bool hasGlyphs; };
     std::vector<LineInfo> lines;
     {
         int start = 0;
@@ -778,6 +773,7 @@ void UITextEdit::moveCursorVertically(bool up)
     const int lineDy = m_font->getGlyphSpacing().height();
     const int areaTop = m_drawArea.top();
     const int areaLeft = m_drawArea.left();
+    const int y0 = areaTop - m_textVirtualOffset.y;
 
     std::vector<int> visToLine(visLen + 1, 0);
     for (size_t k = 0; k < lines.size(); ++k)
@@ -804,13 +800,13 @@ void UITextEdit::moveCursorVertically(bool up)
 
         if (!L.hasGlyphs) {
             const int lineIdx = static_cast<int>(k);
-            const int baseTop = areaTop + lineIdx * (glyphH + lineDy);
+            const int baseTop = y0 + lineIdx * (glyphH + lineDy);
             L.top = baseTop;
             L.bottom = baseTop + glyphH;
             L.left = areaLeft;
             L.right = areaLeft;
         } else {
-            L.top = (top == std::numeric_limits<int>::max()) ? areaTop : top;
+            L.top = (top == std::numeric_limits<int>::max()) ? (y0 + (int)k * (glyphH + lineDy)) : top;
             L.bottom = (bottom == std::numeric_limits<int>::min()) ? (L.top + glyphH) : bottom;
             L.left = (left == std::numeric_limits<int>::max()) ? areaLeft : left;
             L.right = (right == std::numeric_limits<int>::min()) ? areaLeft : right;
@@ -872,14 +868,7 @@ int UITextEdit::getTextPos(const Point& pos)
     if (visLen <= 0)
         return 0;
 
-    struct VLine
-    {
-        int visStart;
-        int visEnd;
-        int top, bottom;
-        int left, right;
-        bool hasGlyphs;
-    };
+    struct VLine { int visStart; int visEnd; int top, bottom; int left, right; bool hasGlyphs; };
     std::vector<VLine> lines;
     lines.reserve(64);
 
@@ -897,6 +886,7 @@ int UITextEdit::getTextPos(const Point& pos)
     const int lineDy = m_font->getGlyphSpacing().height();
     const int areaTop = m_drawArea.top();
     const int areaLeft = m_drawArea.left();
+    const int y0 = areaTop - m_textVirtualOffset.y;
 
     std::vector<int> visToLine(visLen + 1, 0);
     for (size_t k = 0; k < lines.size(); ++k)
@@ -925,7 +915,7 @@ int UITextEdit::getTextPos(const Point& pos)
         if (!L.hasGlyphs) {
             if (k > 0) {
                 const auto& P = lines[k - 1];
-                const int base = (P.bottom > 0 ? P.bottom : (areaTop + (int)(k - 1) * (glyphH + lineDy)));
+                const int base = (P.bottom > 0 ? P.bottom : (y0 + (int)(k - 1) * (glyphH + lineDy)));
                 L.top = base + lineDy;
                 L.bottom = L.top + glyphH;
             } else {
@@ -937,14 +927,14 @@ int UITextEdit::getTextPos(const Point& pos)
                     L.bottom = nextTop - lineDy;
                     L.top = L.bottom - glyphH;
                 } else {
-                    L.top = areaTop;
+                    L.top = y0;
                     L.bottom = L.top + glyphH;
                 }
             }
             L.left = areaLeft;
             L.right = areaLeft;
         } else {
-            L.top = (top == std::numeric_limits<int>::max()) ? (areaTop + (int)k * (glyphH + lineDy)) : top;
+            L.top = (top == std::numeric_limits<int>::max()) ? (y0 + (int)k * (glyphH + lineDy)) : top;
             L.bottom = (bottom == std::numeric_limits<int>::min()) ? (L.top + glyphH) : bottom;
             L.left = (left == std::numeric_limits<int>::max()) ? areaLeft : left;
             L.right = (right == std::numeric_limits<int>::min()) ? areaLeft : right;

--- a/src/framework/ui/uitextedit.cpp
+++ b/src/framework/ui/uitextedit.cpp
@@ -130,9 +130,22 @@ void UITextEdit::drawSelf(const DrawPoolType drawPane)
         constexpr int delay = 333;
         const ticks_t elapsed = g_clock.millis() - m_cursorTicks;
         if (elapsed <= delay) {
-            auto cursorRect = cursorVis > 0
-                ? Rect(m_glyphsCoords[cursorVis - 1].first.right(), m_glyphsCoords[cursorVis - 1].first.top(), 1, m_font->getGlyphHeight())
-                : Rect(m_rect.left() + m_padding.left, m_rect.top() + m_padding.top, 1, m_font->getGlyphHeight());
+            Rect cursorRect;
+
+            if (cursorVis < textLength && m_glyphsCoords[cursorVis].first.isValid()) {
+                const Rect& cur = m_glyphsCoords[cursorVis].first;
+                const bool hasPrev = cursorVis > 0 && m_glyphsCoords[cursorVis - 1].first.isValid();
+                const bool sameLineAsPrev = hasPrev && (m_glyphsCoords[cursorVis - 1].first.top() == cur.top());
+
+                if (!hasPrev || !sameLineAsPrev)
+                    cursorRect = Rect(cur.left(), cur.top(), 1, m_font->getGlyphHeight());
+                else
+                    cursorRect = Rect(m_glyphsCoords[cursorVis - 1].first.right(), m_glyphsCoords[cursorVis - 1].first.top(), 1, m_font->getGlyphHeight());
+            } else if (cursorVis > 0 && m_glyphsCoords[cursorVis - 1].first.isValid()) {
+                cursorRect = Rect(m_glyphsCoords[cursorVis - 1].first.right(), m_glyphsCoords[cursorVis - 1].first.top(), 1, m_font->getGlyphHeight());
+            } else {
+                cursorRect = Rect(m_rect.left() + m_padding.left, m_rect.top() + m_padding.top, 1, m_font->getGlyphHeight());
+            }
 
             const bool useSelectionColor = hasSelection() && m_cursorPos >= m_selectionStart && m_cursorPos <= m_selectionEnd;
             const auto& color = useSelectionColor ? m_selectionColor : m_color;

--- a/src/framework/ui/uitextedit.cpp
+++ b/src/framework/ui/uitextedit.cpp
@@ -139,9 +139,6 @@ void UITextEdit::update(const bool focusCursor, bool disableAreaUpdate)
         return;
 
     std::string text = getDisplayedText();
-    if (m_text.ends_with(" "))
-        text += " ";
-
     m_drawText = text;
     const int textLength = text.length();
 

--- a/src/framework/ui/uitextedit.cpp
+++ b/src/framework/ui/uitextedit.cpp
@@ -919,7 +919,7 @@ int UITextEdit::getTextPos(const Point& pos)
     } else if (pos.x <= L.left) {
         targetVis = L.visStart;
     } else if (pos.x >= L.right) {
-        targetVis = L.visEnd;
+        targetVis = std::max(L.visEnd - 1, L.visStart);
     } else {
         targetVis = L.visEnd;
         for (int j = L.visStart; j < L.visEnd; ++j) {

--- a/src/framework/ui/uitextedit.h
+++ b/src/framework/ui/uitextedit.h
@@ -36,7 +36,7 @@ private:
     void update(bool focusCursor = false, bool disableAreaUpdate = false);
 
 public:
-    void setCursorPos(int pos);
+    void setCursorPos(int pos, bool focusCursor = true);
     void setSelection(int start, int end);
     void setCursorVisible(const bool enable) { setProp(PropCursorVisible, enable); }
     void setChangeCursorImage(const bool enable) { setProp(PropChangeCursorImage, enable); }
@@ -130,7 +130,7 @@ private:
     void disableUpdates() { setProp(PropUpdatesEnabled, false); }
     void enableUpdates() { setProp(PropUpdatesEnabled, true); }
     void recacheGlyphs() { setProp(PropGlyphsMustRecache, true); }
-    void setCursorPosEx(int pos, bool preservePreferredX);
+    void setCursorPosEx(int pos, bool preservePreferredX, bool focusCursor);
 
     std::string m_validCharacters;
     uint32_t m_maxLength{ 0 };

--- a/src/framework/ui/uitextedit.h
+++ b/src/framework/ui/uitextedit.h
@@ -130,6 +130,7 @@ private:
     void disableUpdates() { setProp(PropUpdatesEnabled, false); }
     void enableUpdates() { setProp(PropUpdatesEnabled, true); }
     void recacheGlyphs() { setProp(PropGlyphsMustRecache, true); }
+    void setCursorPosEx(int pos, bool preservePreferredX);
 
     std::string m_validCharacters;
     uint32_t m_maxLength{ 0 };

--- a/src/framework/ui/uitextedit.h
+++ b/src/framework/ui/uitextedit.h
@@ -148,6 +148,7 @@ private:
     int m_selectionStart{ 0 };
     int m_selectionEnd{ 0 };
     int m_cursorPos{ 0 };
+    int m_cursorPreferredX{ -1 };
 
     std::vector<int> m_srcToVis;
     std::vector<int> m_visToSrc;;

--- a/src/framework/ui/uitextedit.h
+++ b/src/framework/ui/uitextedit.h
@@ -149,6 +149,9 @@ private:
     int m_selectionEnd{ 0 };
     int m_cursorPos{ 0 };
 
+    std::vector<int> m_srcToVis;
+    std::vector<int> m_visToSrc;;
+
     Color m_selectionColor{ Color::white };
     Color m_selectionBackgroundColor{ Color::black };
 

--- a/src/framework/ui/uiwidget.h
+++ b/src/framework/ui/uiwidget.h
@@ -938,11 +938,12 @@ protected:
     virtual bool isTextEdit() { return false; }
     void drawText(const Rect& screenCoords);
 
-    void updateHtmlTextSize();
+    void computeHtmlTextIntrinsicSize();
 
     virtual void onTextChange(std::string_view text, std::string_view oldText);
     virtual void onFontChange(std::string_view font);
 
+    WrapOptions m_textWrapOptions;
     std::vector<Point> m_glyphsPositionsCache;
 
     std::string m_text;

--- a/src/framework/ui/uiwidgethtml.cpp
+++ b/src/framework/ui/uiwidgethtml.cpp
@@ -1387,7 +1387,7 @@ void UIWidget::updateSize() {
         auto height = m_textSizeNowrap.height();
         if (parentSize.width() < m_textSizeNowrap.width()) {
             if (isTextWrap() && m_rect.isValid()) {
-                const auto& text = m_font->wrapText(m_text, parentSize.width() - m_textOffset.x);
+                const auto& text = m_font->wrapText(m_text, parentSize.width() - m_textOffset.x, m_textWrapOptions);
                 height *= std::count(text.begin(), text.end(), '\n') + 1;
             }
         }

--- a/vc17/otclient.vcxproj
+++ b/vc17/otclient.vcxproj
@@ -579,6 +579,7 @@
     <ClInclude Include="..\src\framework\graphics\animatedtexture.h" />
     <ClInclude Include="..\src\framework\graphics\apngloader.h" />
     <ClInclude Include="..\src\framework\graphics\bitmapfont.h" />
+    <ClInclude Include="..\src\framework\graphics\bitmapfontwrapoptions.h" />
     <ClInclude Include="..\src\framework\graphics\cachedtext.h" />
     <ClInclude Include="..\src\framework\graphics\coordsbuffer.h" />
     <ClInclude Include="..\src\framework\graphics\declarations.h" />


### PR DESCRIPTION
This PR introduces a **complete rewrite of the text wrapping system**, bringing full **HTML/CSS-like behavior** to OTClient’s text rendering and editing components.

### ✨ New Features
- **CSS-compatible wrap engine** with full semantic support:
  - `word-break`: `normal`, `break-all`, `keep-all`
  - `overflow-wrap`: `normal`, `break-word`, `anywhere`
  - `hyphens`: `none`, `manual`, `auto`
  - Handles `NBSP`, `ZWSP`, word joiners, CJK rules, and language hints.
- **Precise width computation** for all glyphs:
  - Breaks correctly when `lineWidth + next >= maxWidth`.
  - Space characters (`' '`, `NBSP`, etc.) now use their real glyph width.
- **UTF-8 and CJK correctness:** consistent width and wrapping between ASCII, multibyte, and CJK text.
- **Accurate logical-visual index mapping** after wrapping, fixing cursor positioning, hit-testing, and text selection on wrapped lines.
- **Prevents infinite loops** in `UITextEdit::updateDisplayedText()` when dealing with empty source or wrapped strings.
- **Fixes misalignment and truncation** when editing multi-line text with automatic wrapping (fix for #1376).

### 🧩 Improvements
- Better double-click word selection.
- Correct vertical cursor navigation between wrapped lines.
- Fixed cursor rendering on wrapped text.
- Fixed autoscroll not reaching the final line.


https://github.com/user-attachments/assets/a6f571b0-8d93-43ab-ae7b-79e1a3c81ea1

