### PR TITLE
fix(html): correct absolute positioning to ignore parent padding when offsets are defined

### DIFF
--- a/modules/game_htmlsample/htmlsample.css
+++ b/modules/game_htmlsample/htmlsample.css
@@ -20,13 +20,15 @@
 
 .footer {
   position: absolute;
-  right: 0;
-  bottom: 0;
+  left: 5;
+  right: 10;
+  bottom: 10;
 }
 
 .equalizerEffect {
   position: absolute;
-  bottom: 0;
+  bottom: 5;
+  left: 0;
   right: 0;
   text-align: center;
   height: 100px;

--- a/src/framework/ui/uianchorlayout.cpp
+++ b/src/framework/ui/uianchorlayout.cpp
@@ -285,8 +285,11 @@ bool UIAnchorLayout::updateWidget(const UIWidgetPtr& widget, const UIAnchorGroup
                         }
                     }
 
-                    if (widget->getPositionType() == PositionType::Relative || widget->getPositionType() == PositionType::Absolute)
+                    if (widget->getPositionType() == PositionType::Relative || widget->getPositionType() == PositionType::Absolute) {
+                        if (widget->getPositions().left.unit != Unit::Auto)
+                            margin -= hookedWidget->getPaddingLeft();
                         margin += widget->getPositions().left.value;
+                    }
 
                     // Fix anchor position
                     margin += (anchor->getAnchoredEdge() == anchor->getHookedEdge() ? 0 : 1);
@@ -301,9 +304,11 @@ bool UIAnchorLayout::updateWidget(const UIWidgetPtr& widget, const UIAnchorGroup
             case Fw::AnchorRight: {
                 auto margin = widget->getMarginRight();
                 if (widget->isOnHtml()) {
-                    if (widget->getPositions().left.unit == Unit::Auto &&
-                            (widget->getPositionType() == PositionType::Relative || widget->getPositionType() == PositionType::Absolute))
+                    if (widget->getPositions().left.unit == Unit::Auto && (widget->getPositionType() == PositionType::Relative || widget->getPositionType() == PositionType::Absolute)) {
+                        if (widget->getPositions().right.unit != Unit::Auto)
+                            margin -= hookedWidget->getPaddingRight();
                         margin += widget->getPositions().right.value;
+                    }
                 }
 
                 if (!horizontalMoved) {
@@ -342,8 +347,12 @@ bool UIAnchorLayout::updateWidget(const UIWidgetPtr& widget, const UIAnchorGroup
                         margin += widget->getLineHeight().valueCalculed - hookedWidget->getLineHeight().valueCalculed;
                     }
 
-                    if (widget->getPositionType() == PositionType::Relative || widget->getPositionType() == PositionType::Absolute)
+                    if (widget->getPositionType() == PositionType::Relative || widget->getPositionType() == PositionType::Absolute) {
+                        if (widget->getPositions().top.unit != Unit::Auto)
+                            margin -= hookedWidget->getPaddingTop();
+
                         margin += widget->getPositions().top.value;
+                    }
 
                     // Fix anchor position
                     margin += (anchor->getAnchoredEdge() == anchor->getHookedEdge() ? 0 : 1);
@@ -377,8 +386,12 @@ bool UIAnchorLayout::updateWidget(const UIWidgetPtr& widget, const UIAnchorGroup
                     }
 
                     if (widget->getPositions().top.unit == Unit::Auto &&
-        (widget->getPositionType() == PositionType::Relative || widget->getPositionType() == PositionType::Absolute))
+        (widget->getPositionType() == PositionType::Relative || widget->getPositionType() == PositionType::Absolute)) {
+                        if (widget->getPositions().bottom.unit != Unit::Auto)
+                            margin -= hookedWidget->getPaddingBottom();
+
                         margin += widget->getPositions().bottom.value;
+                    }
                 }
 
                 if (!verticalMoved) {

--- a/src/framework/ui/uianchorlayout.cpp
+++ b/src/framework/ui/uianchorlayout.cpp
@@ -304,9 +304,10 @@ bool UIAnchorLayout::updateWidget(const UIWidgetPtr& widget, const UIAnchorGroup
             case Fw::AnchorRight: {
                 auto margin = widget->getMarginRight();
                 if (widget->isOnHtml()) {
+                    if (widget->getPositionType() == PositionType::Absolute && widget->getPositions().right.unit != Unit::Auto)
+                        margin -= hookedWidget->getPaddingRight();
+
                     if (widget->getPositions().left.unit == Unit::Auto && (widget->getPositionType() == PositionType::Relative || widget->getPositionType() == PositionType::Absolute)) {
-                        if (widget->getPositions().right.unit != Unit::Auto)
-                            margin -= hookedWidget->getPaddingRight();
                         margin += widget->getPositions().right.value;
                     }
                 }
@@ -385,11 +386,10 @@ bool UIAnchorLayout::updateWidget(const UIWidgetPtr& widget, const UIAnchorGroup
                             margin += hookedWidget->getPositions().bottom.value;
                     }
 
-                    if (widget->getPositions().top.unit == Unit::Auto &&
-        (widget->getPositionType() == PositionType::Relative || widget->getPositionType() == PositionType::Absolute)) {
-                        if (widget->getPositions().bottom.unit != Unit::Auto)
-                            margin -= hookedWidget->getPaddingBottom();
+                    if (widget->getPositionType() == PositionType::Absolute && widget->getPositions().bottom.unit != Unit::Auto)
+                        margin -= hookedWidget->getPaddingBottom();
 
+                    if (widget->getPositions().top.unit == Unit::Auto && (widget->getPositionType() == PositionType::Relative || widget->getPositionType() == PositionType::Absolute)) {
                         margin += widget->getPositions().bottom.value;
                     }
                 }

--- a/src/framework/ui/uiwidget.h
+++ b/src/framework/ui/uiwidget.h
@@ -730,10 +730,10 @@ public:
     void setX(const int x) { move(x, getY()); }
     void setY(const int y) { move(getX(), y); }
 
-    void setTop(int v) { m_positions.top.unit = Unit::Px; m_positions.top.value = v;  scheduleHtmlTask(PropApplyAnchorAlignment); updateLayout(); }
-    void setBottom(int v) { m_positions.top.unit = Unit::Px; m_positions.bottom.value = v;  scheduleHtmlTask(PropApplyAnchorAlignment); updateLayout(); }
-    void setLeft(int v) { m_positions.top.unit = Unit::Px; m_positions.left.value = v;  scheduleHtmlTask(PropApplyAnchorAlignment); updateLayout(); }
-    void setRight(int v) { m_positions.top.unit = Unit::Px; m_positions.right.value = v;  scheduleHtmlTask(PropApplyAnchorAlignment); updateLayout(); }
+    void setTop(int v) { m_positions.top.unit = Unit::Px; m_positions.top.value = v; scheduleHtmlTask(PropUpdateSize); scheduleHtmlTask(PropApplyAnchorAlignment); updateLayout(); }
+    void setBottom(int v) { m_positions.top.unit = Unit::Px; m_positions.bottom.value = v; scheduleHtmlTask(PropUpdateSize); scheduleHtmlTask(PropApplyAnchorAlignment); updateLayout(); }
+    void setLeft(int v) { m_positions.top.unit = Unit::Px; m_positions.left.value = v;  scheduleHtmlTask(PropUpdateSize); scheduleHtmlTask(PropApplyAnchorAlignment); updateLayout(); }
+    void setRight(int v) { m_positions.top.unit = Unit::Px; m_positions.right.value = v;  scheduleHtmlTask(PropUpdateSize); scheduleHtmlTask(PropApplyAnchorAlignment); updateLayout(); }
 
     void setHeight(std::string heightStr) { applyDimension(false, std::move(heightStr)); }
     void setWidth(std::string widthStr) { applyDimension(true, std::move(widthStr)); }

--- a/src/framework/ui/uiwidgethtml.cpp
+++ b/src/framework/ui/uiwidgethtml.cpp
@@ -811,9 +811,8 @@ void UIWidget::applyDimension(bool isWidth, Unit unit, int16_t value) {
 
     bool needUpdate = false;
 
-    if (m_positionType == PositionType::Absolute && (unit == Unit::Auto || unit == Unit::Percent)) {
-        if (isWidth && m_positions.right.unit == Unit::Auto || !isWidth && m_positions.bottom.unit == Unit::Auto)
-            unit = Unit::FitContent;
+    if (m_positionType == PositionType::Absolute && unit == Unit::Auto) {
+        unit = Unit::FitContent;
     }
 
     switch (unit) {
@@ -1408,14 +1407,13 @@ void UIWidget::updateSize() {
             auto parent = getVirtualParent();
             parent->updateSize();
 
-            const int pContentW = parent->getWidth() - parent->getPaddingLeft() - parent->getPaddingRight();
-            const int pContentH = parent->getHeight() - parent->getPaddingTop() - parent->getPaddingBottom();
-
             auto resolveH = [&](const SizeUnit& len, int base) -> int {
                 return (len.unit == Unit::Percent) ? (base * len.value) / 100 : len.value;
             };
 
             if (updateWidth) {
+                const int pContentW = parent->getWidth();
+
                 const int leftPx = resolveH(m_positions.left, pContentW);
                 const int rightPx = resolveH(m_positions.right, pContentW);
 
@@ -1430,6 +1428,7 @@ void UIWidget::updateSize() {
             }
 
             if (updateHeight) {
+                const int pContentH = parent->getHeight();
                 const int topPx = resolveH(m_positions.top, pContentH);
                 const int bottomPx = resolveH(m_positions.bottom, pContentH);
 
@@ -1459,13 +1458,13 @@ void UIWidget::updateSize() {
 
         if (widthNeedsUpdate) {
             width = parent->getWidth();
-            if (width > -1)
+            if (width > -1 && m_positionType != PositionType::Absolute)
                 width -= parent->getPaddingLeft() + parent->getPaddingRight();
         }
 
         if (heightNeedsUpdate) {
             height = parent->getHeight();
-            if (height > -1)
+            if (height > -1 && m_positionType != PositionType::Absolute)
                 height -= parent->getPaddingTop() + parent->getPaddingBottom();
         }
 

--- a/src/framework/ui/uiwidgethtml.cpp
+++ b/src/framework/ui/uiwidgethtml.cpp
@@ -1398,13 +1398,8 @@ void UIWidget::updateSize() {
         if (!cb) return;
         cb->updateSize();
 
-        const int pl = cb->getPaddingLeft();
-        const int pr = cb->getPaddingRight();
-        const int pt = cb->getPaddingTop();
-        const int pb = cb->getPaddingBottom();
-
-        const int cbw = std::max(0, cb->getWidth() + pl + pr);
-        const int cbh = std::max(0, cb->getHeight() + pt + pb);
+        const int cbw = std::max(0, cb->getWidth());
+        const int cbh = std::max(0, cb->getHeight());
 
         auto toPx = [&](const SizeUnit& u, int base) -> int {
             switch (u.unit) {
@@ -1553,8 +1548,6 @@ void UIWidget::updateSize() {
             setMarginLeft(std::max(0, (left == INT_MIN ? 0 : left)));
         } else if (hasR) {
             setMarginRight(std::max(0, (right == INT_MIN ? 0 : right)));
-        } else {
-            setMarginLeft(pl);
         }
 
         if (hasT && hasB) {
@@ -1564,8 +1557,6 @@ void UIWidget::updateSize() {
             setMarginTop(std::max(0, (top == INT_MIN ? 0 : top)));
         } else if (hasB) {
             setMarginBottom(std::max(0, (bottom == INT_MIN ? 0 : bottom)));
-        } else {
-            setMarginTop(pt);
         }
     }
 

--- a/src/framework/ui/uiwidgethtml.cpp
+++ b/src/framework/ui/uiwidgethtml.cpp
@@ -1389,58 +1389,183 @@ void UIWidget::updateSize() {
             setProp(PropTextHorizontalAutoResize, false);
             setWidth_px(m_parent->getSize().width());
         }
-
         updateText();
         return;
     }
 
     if (m_positionType == PositionType::Absolute) {
-        const bool L = m_positions.left.unit != Unit::Auto;
-        const bool R = m_positions.right.unit != Unit::Auto;
-        const bool T = m_positions.top.unit != Unit::Auto;
-        const bool B = m_positions.bottom.unit != Unit::Auto;
+        UIWidgetPtr cb = getVirtualParent();
+        if (!cb) return;
+        cb->updateSize();
 
-        const bool updateWidth = m_width.needsUpdate(Unit::Auto, SIZE_VERSION_COUNTER) && L && R;
-        const bool updateHeight = m_height.needsUpdate(Unit::FitContent, SIZE_VERSION_COUNTER) && T && B;
+        const int pl = cb->getPaddingLeft();
+        const int pr = cb->getPaddingRight();
+        const int pt = cb->getPaddingTop();
+        const int pb = cb->getPaddingBottom();
 
-        if (updateWidth || updateHeight) {
-            auto parent = getVirtualParent();
-            parent->updateSize();
+        const int cbw = std::max(0, cb->getWidth() + pl + pr);
+        const int cbh = std::max(0, cb->getHeight() + pt + pb);
 
-            auto resolveH = [&](const SizeUnit& len, int base) -> int {
-                return (len.unit == Unit::Percent) ? (base * len.value) / 100 : len.value;
-            };
+        auto toPx = [&](const SizeUnit& u, int base) -> int {
+            switch (u.unit) {
+                case Unit::Percent: return std::lround(base * (u.value / 100.0));
+                case Unit::Px: return u.value;
+                default: return 0;
+            }
+        };
 
-            if (updateWidth) {
-                const int pContentW = parent->getWidth();
+        const bool hasL = m_positions.left.unit != Unit::Auto;
+        const bool hasR = m_positions.right.unit != Unit::Auto;
+        const bool hasT = m_positions.top.unit != Unit::Auto;
+        const bool hasB = m_positions.bottom.unit != Unit::Auto;
 
-                const int leftPx = resolveH(m_positions.left, pContentW);
-                const int rightPx = resolveH(m_positions.right, pContentW);
+        int left = hasL ? toPx(m_positions.left, cbw) : INT_MIN;
+        int right = hasR ? toPx(m_positions.right, cbw) : INT_MIN;
+        int top = hasT ? toPx(m_positions.top, cbh) : INT_MIN;
+        int bottom = hasB ? toPx(m_positions.bottom, cbh) : INT_MIN;
 
-                const int ml = getMarginLeft();
-                const int mr = getMarginRight();
+        const int ml = getMarginLeft();
+        const int mr = getMarginRight();
+        const int mt = getMarginTop();
+        const int mb = getMarginBottom();
 
-                int w = pContentW - leftPx - rightPx - ml - mr;
-                if (w < 0) w = 0;
+        bool widthAutoLike =
+            m_width.unit == Unit::Auto || m_width.unit == Unit::FitContent ||
+            m_width.needsUpdate(Unit::Auto, SIZE_VERSION_COUNTER) ||
+            m_width.needsUpdate(Unit::FitContent, SIZE_VERSION_COUNTER);
 
+        int resolvedW = getWidth();
+        if (resolvedW < 0 && m_width.valueCalculed > -1) resolvedW = m_width.valueCalculed;
+
+        auto shrinkToFitWidth = [&]() -> int {
+            int w = 0, h = 0;
+            applyFitContentRecursive(this, w, h);
+            return std::max(0, w);
+        };
+
+        if (hasL && hasR && widthAutoLike) {
+            int w = cbw - left - right - ml - mr;
+            if (w < 0) w = 0;
+            setWidth_px(w);
+            m_width.applyUpdate(getWidth(), SIZE_VERSION_COUNTER);
+            resolvedW = getWidth();
+        } else if ((hasL && !hasR && !widthAutoLike) || (hasR && !hasL && !widthAutoLike)) {
+            int w = std::max(0, resolvedW);
+            int other = cbw - (hasL ? left : right) - w - ml - mr;
+            if (hasL) right = other; else left = other;
+        } else if (hasL && hasR && !widthAutoLike) {
+            int w = std::max(0, resolvedW);
+            right = cbw - left - w - ml - mr;
+        } else {
+            if (widthAutoLike) {
+                int w = shrinkToFitWidth();
                 setWidth_px(w);
                 m_width.applyUpdate(getWidth(), SIZE_VERSION_COUNTER);
+                resolvedW = getWidth();
             }
+            if (!hasL && !hasR) {
+                left = 0;
+                right = cbw - left - std::max(0, resolvedW) - ml - mr;
+            } else if (!hasL) {
+                left = cbw - right - std::max(0, resolvedW) - ml - mr;
+            } else {
+                right = cbw - left - std::max(0, resolvedW) - ml - mr;
+            }
+        }
 
-            if (updateHeight) {
-                const int pContentH = parent->getHeight();
-                const int topPx = resolveH(m_positions.top, pContentH);
-                const int bottomPx = resolveH(m_positions.bottom, pContentH);
+        if (m_minSize.width() > 0 || m_maxSize.width() > 0) {
+            int clamped = std::max(m_minSize.width(), std::max(0, resolvedW));
+            if (m_maxSize.width() > 0) clamped = std::min(m_maxSize.width(), clamped);
+            if (clamped != resolvedW) {
+                setWidth_px(clamped);
+                m_width.applyUpdate(getWidth(), SIZE_VERSION_COUNTER);
+                resolvedW = clamped;
+                if (hasL) right = cbw - left - resolvedW - ml - mr;
+                else left = cbw - right - resolvedW - ml - mr;
+            }
+        }
 
-                const int mt = getMarginTop();
-                const int mb = getMarginBottom();
+        bool heightAutoLike =
+            m_height.unit == Unit::Auto || m_height.unit == Unit::FitContent ||
+            m_height.needsUpdate(Unit::Auto, SIZE_VERSION_COUNTER) ||
+            m_height.needsUpdate(Unit::FitContent, SIZE_VERSION_COUNTER);
 
-                int h = pContentH - topPx - bottomPx - mt - mb;
-                if (h < 0) h = 0;
+        int resolvedH = getHeight();
+        if (resolvedH < 0 && m_height.valueCalculed > -1) resolvedH = m_height.valueCalculed;
 
+        auto shrinkToFitHeight = [&]() -> int {
+            int w = 0, h = 0;
+            applyFitContentRecursive(this, w, h);
+            return std::max(0, h);
+        };
+
+        if (hasT && hasB && heightAutoLike) {
+            int h = cbh - top - bottom - mt - mb;
+            if (h < 0) h = 0;
+            setHeight_px(h);
+            m_height.applyUpdate(getHeight(), SIZE_VERSION_COUNTER);
+            resolvedH = getHeight();
+        } else if ((hasT && !hasB && !heightAutoLike) || (hasB && !hasT && !heightAutoLike)) {
+            int h = std::max(0, resolvedH);
+            int other = cbh - (hasT ? top : bottom) - h - mt - mb;
+            if (hasT) bottom = other; else top = other;
+        } else if (hasT && hasB && !heightAutoLike) {
+            int h = std::max(0, resolvedH);
+            bottom = cbh - top - h - mt - mb;
+        } else {
+            if (heightAutoLike) {
+                int h = shrinkToFitHeight();
                 setHeight_px(h);
                 m_height.applyUpdate(getHeight(), SIZE_VERSION_COUNTER);
+                resolvedH = getHeight();
             }
+            if (!hasT && !hasB) {
+                top = 0;
+                bottom = cbh - top - std::max(0, resolvedH) - mt - mb;
+            } else if (!hasT) {
+                top = cbh - bottom - std::max(0, resolvedH) - mt - mb;
+            } else {
+                bottom = cbh - top - std::max(0, resolvedH) - mt - mb;
+            }
+        }
+
+        if (m_minSize.height() > 0 || m_maxSize.height() > 0) {
+            int clamped = std::max(m_minSize.height(), std::max(0, resolvedH));
+            if (m_maxSize.height() > 0) clamped = std::min(m_maxSize.height(), clamped);
+            if (clamped != resolvedH) {
+                setHeight_px(clamped);
+                m_height.applyUpdate(getHeight(), SIZE_VERSION_COUNTER);
+                resolvedH = clamped;
+                if (hasT) bottom = cbh - top - resolvedH - mt - mb;
+                else top = cbh - bottom - resolvedH - mt - mb;
+            }
+        }
+
+        setMarginLeft(0);
+        setMarginRight(0);
+        setMarginTop(0);
+        setMarginBottom(0);
+
+        if (hasL && hasR) {
+            setMarginLeft(std::max(0, left));
+            setMarginRight(std::max(0, right));
+        } else if (hasL) {
+            setMarginLeft(std::max(0, (left == INT_MIN ? 0 : left)));
+        } else if (hasR) {
+            setMarginRight(std::max(0, (right == INT_MIN ? 0 : right)));
+        } else {
+            setMarginLeft(pl);
+        }
+
+        if (hasT && hasB) {
+            setMarginTop(std::max(0, top));
+            setMarginBottom(std::max(0, bottom));
+        } else if (hasT) {
+            setMarginTop(std::max(0, (top == INT_MIN ? 0 : top)));
+        } else if (hasB) {
+            setMarginBottom(std::max(0, (bottom == INT_MIN ? 0 : bottom)));
+        } else {
+            setMarginTop(pt);
         }
     }
 
@@ -1450,24 +1575,20 @@ void UIWidget::updateSize() {
     if (widthNeedsUpdate || heightNeedsUpdate) {
         auto width = -1;
         auto height = -1;
-
         auto parent = m_parent;
         while (m_positionType == PositionType::Absolute && parent->m_positionType == PositionType::Static) {
             parent = parent->m_parent;
         }
-
         if (widthNeedsUpdate) {
             width = parent->getWidth();
             if (width > -1 && m_positionType != PositionType::Absolute)
                 width -= parent->getPaddingLeft() + parent->getPaddingRight();
         }
-
         if (heightNeedsUpdate) {
             height = parent->getHeight();
             if (height > -1 && m_positionType != PositionType::Absolute)
                 height -= parent->getPaddingTop() + parent->getPaddingBottom();
         }
-
         if (width > -1 || height > -1) {
             updateDimension(this, width, height);
         }
@@ -1511,9 +1632,8 @@ void UIWidget::applyAnchorAlignment() {
 
     resetAnchors();
 
-    if (m_displayType == DisplayType::None) {
+    if (m_displayType == DisplayType::None)
         return;
-    }
 
     if (!hasAnchoredLayout())
         return;
@@ -1527,9 +1647,35 @@ void UIWidget::applyAnchorAlignment() {
     if (m_parent && m_parent->getDisplay() == DisplayType::TableCell) {
         const auto ta = resolveCellTextAlign(this);
         const auto va = resolveCellVerticalAlign(this);
-
         anchorHorizontalInCell(this, ta);
         anchorVerticalInCell(this, va);
+        return;
+    }
+
+    if (m_positionType == PositionType::Absolute) {
+        const auto& pos = getPositions();
+        const bool L = pos.left.unit != Unit::Auto;
+        const bool R = pos.right.unit != Unit::Auto;
+        const bool T = pos.top.unit != Unit::Auto;
+        const bool B = pos.bottom.unit != Unit::Auto;
+
+        if (L && R) {
+            addAnchor(Fw::AnchorLeft, "parent", Fw::AnchorLeft);
+            addAnchor(Fw::AnchorRight, "parent", Fw::AnchorRight);
+        } else if (R && !L) {
+            addAnchor(Fw::AnchorRight, "parent", Fw::AnchorRight);
+        } else {
+            addAnchor(Fw::AnchorLeft, "parent", Fw::AnchorLeft);
+        }
+
+        if (T && B) {
+            addAnchor(Fw::AnchorTop, "parent", Fw::AnchorTop);
+            addAnchor(Fw::AnchorBottom, "parent", Fw::AnchorBottom);
+        } else if (B && !T) {
+            addAnchor(Fw::AnchorBottom, "parent", Fw::AnchorBottom);
+        } else {
+            addAnchor(Fw::AnchorTop, "parent", Fw::AnchorTop);
+        }
         return;
     }
 
@@ -1544,7 +1690,6 @@ void UIWidget::applyAnchorAlignment() {
 
     if (parentDisplay == DisplayType::InlineBlock || parentDisplay == DisplayType::Block || parentDisplay == DisplayType::TableCell) {
         bool anchored = true;
-
         const auto isInline = isInlineLike(m_displayType);
 
         if (isInline && m_parent->getTextAlign() == Fw::AlignCenter ||
@@ -1561,7 +1706,7 @@ void UIWidget::applyAnchorAlignment() {
                 else
                     addAnchor(Fw::AnchorLeft, "parent", Fw::AnchorLeft);
             } else if (isInline && m_parent->getTextAlign() == Fw::AlignRight ||
-                    !isInline && m_parent->getJustifyItems() == JustifyItemsType::Right) {
+                       !isInline && m_parent->getJustifyItems() == JustifyItemsType::Right) {
                 if (ctx.lastNormalWidget)
                     addAnchor(Fw::AnchorRight, "next", Fw::AnchorLeft);
                 else
@@ -1571,10 +1716,9 @@ void UIWidget::applyAnchorAlignment() {
 
         if (m_positionType != PositionType::Absolute) {
             bool addVertical = false;
-
-            if (parentDisplay == DisplayType::InlineBlock) {
+            if (parentDisplay == DisplayType::InlineBlock)
                 addVertical = m_parent->getHtmlNode()->getStyle("vertical-align") == "middle";
-            } else
+            else
                 addVertical = m_parent->getHtmlNode()->getStyle("align-items") == "center";
 
             if (addVertical) {
@@ -1596,32 +1740,16 @@ void UIWidget::applyAnchorAlignment() {
         }
     }
 
-    if (m_positionType == PositionType::Absolute) {
-        if (getPositions().top.unit == Unit::Auto && getPositions().bottom.unit != Unit::Auto) {
-            addAnchor(Fw::AnchorBottom, "parent", Fw::AnchorBottom);
-        } else {
-            addAnchor(Fw::AnchorTop, "parent", Fw::AnchorTop);
-        }
-
-        if (getPositions().left.unit == Unit::Auto && getPositions().right.unit != Unit::Auto) {
-            addAnchor(Fw::AnchorRight, "parent", Fw::AnchorRight);
-        } else {
-            addAnchor(Fw::AnchorLeft, "parent", Fw::AnchorLeft);
-        }
-
-        return;
-    }
-
     const ClearType effClear = mapLogicalClear(m_clearType);
     const bool topCleared = applyClear(this, ctx, effClear);
 
-    if (effFloat == FloatType::Left || effFloat == FloatType::Right) {
+    if (effFloat == FloatType::Left || effFloat == FloatType::Right)
         applyFloat(this, ctx, effFloat, topCleared);
-    } else if (isFlexContainer(parentDisplay)) {
+    else if (isFlexContainer(parentDisplay))
         applyFlex(this, ctx, topCleared);
-    } else if (isGridContainer(parentDisplay)) {
+    else if (isGridContainer(parentDisplay))
         applyGridOrTable(this, ctx, topCleared);
-    } else if (isTableBox(parentDisplay)) {
+    else if (isTableBox(parentDisplay)) {
         switch (parentDisplay) {
             case DisplayType::Table: {
                 if (m_displayType == DisplayType::TableCaption)
@@ -1647,9 +1775,8 @@ void UIWidget::applyAnchorAlignment() {
                 break;
             }
         }
-    } else if (isInlineLike(m_displayType)) {
+    } else if (isInlineLike(m_displayType))
         applyInline(this, ctx, topCleared);
-    } else {
+    else
         applyBlock(this, ctx, topCleared);
-    }
 }

--- a/src/framework/ui/uiwidgethtml.cpp
+++ b/src/framework/ui/uiwidgethtml.cpp
@@ -1393,6 +1393,31 @@ void UIWidget::updateSize() {
         return;
     }
 
+    const bool widthNeedsUpdate = m_width.needsUpdate(Unit::Auto, SIZE_VERSION_COUNTER) || m_width.needsUpdate(Unit::Percent, SIZE_VERSION_COUNTER);
+    const bool heightNeedsUpdate = m_height.needsUpdate(Unit::Percent, SIZE_VERSION_COUNTER);
+
+    if (widthNeedsUpdate || heightNeedsUpdate) {
+        auto width = -1;
+        auto height = -1;
+        auto parent = m_parent;
+        while (m_positionType == PositionType::Absolute && parent->m_positionType == PositionType::Static) {
+            parent = parent->m_parent;
+        }
+        if (widthNeedsUpdate) {
+            width = parent->getWidth();
+            if (width > -1 && m_positionType != PositionType::Absolute)
+                width -= parent->getPaddingLeft() + parent->getPaddingRight();
+        }
+        if (heightNeedsUpdate) {
+            height = parent->getHeight();
+            if (height > -1 && m_positionType != PositionType::Absolute)
+                height -= parent->getPaddingTop() + parent->getPaddingBottom();
+        }
+        if (width > -1 || height > -1) {
+            updateDimension(this, width, height);
+        }
+    }
+
     if (m_positionType == PositionType::Absolute) {
         UIWidgetPtr cb = getVirtualParent();
         if (!cb) return;
@@ -1571,31 +1596,6 @@ void UIWidget::updateSize() {
             setMarginTop(std::max(0, (top == INT_MIN ? 0 : top)));
         } else if (hasB) {
             setMarginBottom(std::max(0, (bottom == INT_MIN ? 0 : bottom)));
-        }
-    }
-
-    const bool widthNeedsUpdate = m_width.needsUpdate(Unit::Auto, SIZE_VERSION_COUNTER) || m_width.needsUpdate(Unit::Percent, SIZE_VERSION_COUNTER);
-    const bool heightNeedsUpdate = m_height.needsUpdate(Unit::Percent, SIZE_VERSION_COUNTER);
-
-    if (widthNeedsUpdate || heightNeedsUpdate) {
-        auto width = -1;
-        auto height = -1;
-        auto parent = m_parent;
-        while (m_positionType == PositionType::Absolute && parent->m_positionType == PositionType::Static) {
-            parent = parent->m_parent;
-        }
-        if (widthNeedsUpdate) {
-            width = parent->getWidth();
-            if (width > -1 && m_positionType != PositionType::Absolute)
-                width -= parent->getPaddingLeft() + parent->getPaddingRight();
-        }
-        if (heightNeedsUpdate) {
-            height = parent->getHeight();
-            if (height > -1 && m_positionType != PositionType::Absolute)
-                height -= parent->getPaddingTop() + parent->getPaddingBottom();
-        }
-        if (width > -1 || height > -1) {
-            updateDimension(this, width, height);
         }
     }
 


### PR DESCRIPTION
This update aligns the **absolute positioning system** with the behavior of modern browsers (CSS specification).

## 🧩 Changes
- Updated `UIWidget::updateSize()` to use the **parent’s content box** instead of the padding box when computing absolute offsets (`top`, `left`, `right`, `bottom`) with explicit values.  
- When any of these offsets are **not `auto`**, the parent’s padding no longer affects the element’s final position.  
- Preserves the correct behavior for `auto` values, which continue to consider the parent’s padding as part of the containing block.

## ✅ Result
- `position:absolute` now behaves **identically to browsers**:  
  - `top:0` aligns directly with the parent’s content area, **ignoring padding**.  
  - `auto` offsets still follow the standard flow using the padding box as reference.  
- Ensures consistent layout rendering and predictable alignment across all HTML widget hierarchies.