### PR TITLE
feat(ui): add placement attribute for element alignment

### DIFF
--- a/modules/game_htmlsample/htmlsample.html
+++ b/modules/game_htmlsample/htmlsample.html
@@ -4,7 +4,7 @@
   self.msg = "Welcome to HTML/CSS";
 </script>
 <html>
-  <window class="content" anchor="parent" *title="self.title">
+  <window class="content" placement="center" *title="self.title">
     <img class="shield" src="/data/images/ui/character/offhand" />
 
     <div style="padding: 15px; text-align: center">{{self.msg}}</div>

--- a/src/framework/luafunctions.cpp
+++ b/src/framework/luafunctions.cpp
@@ -680,6 +680,7 @@ void Application::registerLuaFunctions()
     g_lua.bindClassMemberFunction<UIWidget>("setBottom", &UIWidget::setBottom);
     g_lua.bindClassMemberFunction<UIWidget>("setRight", &UIWidget::setRight);
     g_lua.bindClassMemberFunction<UIWidget>("setLeft", &UIWidget::setLeft);
+    g_lua.bindClassMemberFunction<UIWidget>("setPlacement", &UIWidget::setPlacement);
 
     g_lua.bindClassMemberFunction<UIWidget>("getX", &UIWidget::getX);
     g_lua.bindClassMemberFunction<UIWidget>("getY", &UIWidget::getY);

--- a/src/framework/ui/uitranslator.cpp
+++ b/src/framework/ui/uitranslator.cpp
@@ -58,6 +58,23 @@ Fw::AlignmentFlag Fw::translateAlignment(std::string aligment)
     return AlignNone;
 }
 
+Fw::AlignmentFlag Fw::translatePlacement(std::string s) {
+    stdext::tolower(s);
+
+    if (s == "auto" || s.empty()) return Fw::AlignNone;
+    if (s == "top-left") return Fw::AlignTopLeft;
+    if (s == "top-right") return Fw::AlignTopRight;
+    if (s == "bottom-left") return Fw::AlignBottomLeft;
+    if (s == "bottom-right") return Fw::AlignBottomRight;
+    if (s == "left-center" || s == "center-left") return Fw::AlignLeftCenter;
+    if (s == "right-center" || s == "center-right") return Fw::AlignRightCenter;
+    if (s == "top-center" || s == "center-top") return Fw::AlignTopCenter;
+    if (s == "bottom-center" || s == "center-bottom") return Fw::AlignBottomCenter;
+    if (s == "center" || s == "middle") return Fw::AlignCenter;
+
+    return Fw::AlignTopLeft;
+}
+
 Fw::AnchorEdge Fw::translateAnchorEdge(std::string anchorEdge)
 {
     stdext::tolower(anchorEdge);

--- a/src/framework/ui/uitranslator.h
+++ b/src/framework/ui/uitranslator.h
@@ -28,6 +28,7 @@
 namespace Fw
 {
     AlignmentFlag translateAlignment(std::string aligment);
+    AlignmentFlag translatePlacement(std::string s);
     AnchorEdge translateAnchorEdge(std::string anchorEdge);
     WidgetState translateState(std::string state);
     AutoFocusPolicy translateAutoFocusPolicy(std::string policy);

--- a/src/framework/ui/uiwidget.cpp
+++ b/src/framework/ui/uiwidget.cpp
@@ -2357,3 +2357,8 @@ void UIWidget::setAlignSelf(AlignSelf align)
     m_flexItem.alignSelf = align;
     updateParentLayout();
 }
+
+void UIWidget::setPlacement(const std::string& placement) {
+    m_placement = Fw::translatePlacement(placement);
+    scheduleHtmlTask(PropApplyAnchorAlignment);
+}

--- a/src/framework/ui/uiwidget.h
+++ b/src/framework/ui/uiwidget.h
@@ -327,7 +327,7 @@ protected:
     OverflowType m_overflowType = OverflowType::Hidden;
     PositionType m_positionType = PositionType::Static;
     uint32_t m_flexLayoutVersion = 0;
-
+    Fw::AlignmentFlag m_placement = Fw::AlignNone;
     SizeUnit m_width;
     SizeUnit m_height;
     SizeUnit m_lineHeight;
@@ -440,6 +440,9 @@ public:
     void setFlexShrink(float shrink);
     void setFlexBasis(const FlexBasis& basis);
     void setAlignSelf(AlignSelf align);
+    void setPlacement(const std::string& placement);
+
+    auto getPlacement() const { return m_placement; }
     FlexDirection getFlexDirection() const { return m_flexContainer.direction; }
     FlexWrap getFlexWrap() const { return m_flexContainer.wrap; }
     JustifyContent getJustifyContent() const { return m_flexContainer.justify; }

--- a/src/framework/ui/uiwidgethtml.cpp
+++ b/src/framework/ui/uiwidgethtml.cpp
@@ -752,6 +752,64 @@ namespace {
             w->getHeightHtml().applyUpdate(w->getHeight(), SIZE_VERSION_COUNTER);
         }
     }
+
+    void applyPlacementAnchors(UIWidget* widget)
+    {
+        if (!widget) return;
+
+        auto align = widget->getPlacement();
+        if (align == Fw::AlignNone) return;
+
+        switch (align) {
+            case Fw::AlignTopLeft:
+                widget->addAnchor(Fw::AnchorLeft, "parent", Fw::AnchorLeft);
+                widget->addAnchor(Fw::AnchorTop, "parent", Fw::AnchorTop);
+                break;
+
+            case Fw::AlignTopRight:
+                widget->addAnchor(Fw::AnchorRight, "parent", Fw::AnchorRight);
+                widget->addAnchor(Fw::AnchorTop, "parent", Fw::AnchorTop);
+                break;
+
+            case Fw::AlignBottomLeft:
+                widget->addAnchor(Fw::AnchorLeft, "parent", Fw::AnchorLeft);
+                widget->addAnchor(Fw::AnchorBottom, "parent", Fw::AnchorBottom);
+                break;
+
+            case Fw::AlignBottomRight:
+                widget->addAnchor(Fw::AnchorRight, "parent", Fw::AnchorRight);
+                widget->addAnchor(Fw::AnchorBottom, "parent", Fw::AnchorBottom);
+                break;
+
+            case Fw::AlignLeftCenter:
+                widget->addAnchor(Fw::AnchorLeft, "parent", Fw::AnchorLeft);
+                widget->addAnchor(Fw::AnchorVerticalCenter, "parent", Fw::AnchorVerticalCenter);
+                break;
+
+            case Fw::AlignRightCenter:
+                widget->addAnchor(Fw::AnchorRight, "parent", Fw::AnchorRight);
+                widget->addAnchor(Fw::AnchorVerticalCenter, "parent", Fw::AnchorVerticalCenter);
+                break;
+
+            case Fw::AlignTopCenter:
+                widget->addAnchor(Fw::AnchorTop, "parent", Fw::AnchorTop);
+                widget->addAnchor(Fw::AnchorHorizontalCenter, "parent", Fw::AnchorHorizontalCenter);
+                break;
+
+            case Fw::AlignBottomCenter:
+                widget->addAnchor(Fw::AnchorBottom, "parent", Fw::AnchorBottom);
+                widget->addAnchor(Fw::AnchorHorizontalCenter, "parent", Fw::AnchorHorizontalCenter);
+                break;
+
+            case Fw::AlignCenter:
+                widget->addAnchor(Fw::AnchorVerticalCenter, "parent", Fw::AnchorVerticalCenter);
+                widget->addAnchor(Fw::AnchorHorizontalCenter, "parent", Fw::AnchorHorizontalCenter);
+                break;
+
+            default:
+                break;
+        }
+    }
 }
 
 void UIWidget::refreshHtml(bool siblingsTo) {
@@ -1643,9 +1701,8 @@ void UIWidget::applyAnchorAlignment() {
     if (!hasAnchoredLayout())
         return;
 
-    if (m_htmlNode->getAttr("anchor") == "parent") {
-        addAnchor(Fw::AnchorLeft, "parent", Fw::AnchorLeft);
-        addAnchor(Fw::AnchorTop, "parent", Fw::AnchorTop);
+    if (m_placement != Fw::AlignNone) {
+        applyPlacementAnchors(this);
         return;
     }
 


### PR DESCRIPTION
### ✨ New Feature: Placement Attribute

This PR adds the **`placement`** attribute, enabling elements to define their
alignment relative to the parent container using HTML/CSS-like behavior.

#### 🧭 Supported Values
| Value | Description |
|--------|-------------|
| `auto` *(default)* | Follows standard HTML/CSS positioning rules |
| `top-left` | Anchored to the top-left corner |
| `top-right` | Anchored to the top-right corner |
| `bottom-left` | Anchored to the bottom-left corner |
| `bottom-right` | Anchored to the bottom-right corner |
| `left-center` / `center-left` | Left-aligned, vertically centered |
| `right-center` / `center-right` | Right-aligned, vertically centered |
| `top-center` / `center-top` | Top-aligned, horizontally centered |
| `bottom-center` / `center-bottom` | Bottom-aligned, horizontally centered |
| `center` / `middle` | Fully centered both vertically and horizontally |

#### ✅ Behavior
- `auto` serves as the default mode, applying anchors that follow HTML/CSS layout logic.
- Other values define explicit anchor-based alignment relative to the parent.

#### 💡 Example
```html
<div placement="auto" />
<div placement="top-right" />
<div placement="bottom-center" />
<div placement="center" />