### PR TITLE
fix(html): use placement position in older modules html/css

### DIFF
--- a/modules/game_blessing/blessing.html
+++ b/modules/game_blessing/blessing.html
@@ -114,17 +114,17 @@
 </style>
 
 <html>
-<Window id="main" class="blessings-window" title="Blessings" onescape="self:close()">
+<Window id="main" placement="center" class="blessings-window" title="Blessings" onescape="self:close()">
 
   <!-- History Panel (initially hidden) -->
-  <div id="historyPanel" anchor="parent" class="history-panel minipanel" title="History"
+  <div id="historyPanel" placement="top-left" class="history-panel minipanel" title="History"
     *if="self.historyButtonText == 'Back'">
     <div id="historyScrollArea" class="history-scroll">
     </div>
   </div>
 
   <!-- Blessing Records Panel -->
-  <div id="blessingsRecordPanel" anchor="parent" class="record-panel minipanel" title="Record of Blessings"
+  <div id="blessingsRecordPanel" placement="top-left" class="record-panel minipanel" title="Record of Blessings"
     layout="type: horizontalBox">
   </div>
 

--- a/modules/game_blessing/blessing.lua
+++ b/modules/game_blessing/blessing.lua
@@ -66,9 +66,6 @@ function show()
     BlessingController.ui:raise()
     BlessingController.ui:focus()
     setBlessingView()
-    BlessingController:scheduleEvent(function()
-        BlessingController.ui:centerIn('parent')
-    end, 1, "LazyHtml")
 end
 
 function hide()

--- a/modules/game_questlog/game_questlog.css
+++ b/modules/game_questlog/game_questlog.css
@@ -1,7 +1,7 @@
 .questLog-window {
   position: relative;
   width: 790px;
-  height: 639px;
+  height: 619px;
   font: verdana-11px-antialised;
   display: block;
   color: #929292
@@ -81,7 +81,7 @@
 #trackerButton {
   float: right;
   margin-right: 2px;
-  width: 35px;
+  width: 85px;
 }
 
 #closeButton {

--- a/modules/game_questlog/game_questlog.html
+++ b/modules/game_questlog/game_questlog.html
@@ -1,8 +1,8 @@
 <link href="game_questlog.css" />
 <html>
-<window id="main" anchor="parent" class="questLog-window" title="Quest Log" onescape="self:close()">
+<window id="main" placement="center" class="questLog-window" title="Quest Log" onescape="self:close()">
 
-  <div id="panelQuestLog" title="Quest Log" focusable="false" class="content-left minipanel" anchor="parent"
+  <div id="panelQuestLog" title="Quest Log" class="content-left minipanel" placement="top-left"
     layout="type: verticalBox;spacing:5">
     <TextListQuestLog id="areaPanelQuestList" class="quest-list"></TextListQuestLog>
     <select id="comboBoxFilter" onchange="self:onFilterQuestLog(event)">
@@ -18,27 +18,27 @@
       <tr>
         <td class="col1">
           <label>
-            <input type="checkbox" id="checkboxShowComplete" checked onchange="filterQuestListShowComplete(event)">
+            <input type="checkbox" id="checkboxShowComplete" checked onchange="self:filterQuestListShowComplete(event)">
             Show completed
           </label>
         </td>
         <td class="col2">Quests completed:</td>
-        <td class="col3" id="lblCompleteNumber"></td>
+        <td class="col3" id="lblCompleteNumber">0</td>
       </tr>
       <tr>
         <td class="col1">
           <label>
-            <input type="checkbox" id="checkboxShowHidden" onchange="filterQuestListShowHidden(event)">
+            <input type="checkbox" id="checkboxShowHidden" onchange="self:filterQuestListShowHidden(event)">
             Show hidden
           </label>
         </td>
         <td class="col2">Quests hidden:</td>
-        <td class="col3" id="lblHiddenNumber"></td>
+        <td class="col3" id="lblHiddenNumber">0</td>
       </tr>
     </table>
   </div>
 
-  <div id="panelQuestLineSelected" focusable="false" class="content-right minipanel" anchor="parent" title="No quest line Selected"
+  <div id="panelQuestLineSelected" focusable="false" class="content-right minipanel" placement="top-left" title="No quest line Selected"
     layout="type: verticalBox;">
     <TextListQuestLog id="ScrollAreaQuestList" ></TextListQuestLog>
     <MultiLineQuestLog id="panelQuestInfo" class="quest-info"></MultiLineQuestLog>
@@ -49,8 +49,8 @@
   <hr class="separator"/>
 
   <div id="buttonsPanel" class="buttons" focusable="false">
-    <button id="trackerButton" onclick="self:toggleMiniWindowsTracker()" text="Quest Tracker"></button>
-    <button id="closeButton" onclick="self:close()" text="Close"></button>
+    <button id="trackerButton" onclick="self:toggleMiniWindowsTracker()" >Quest Tracker</button>
+    <button id="closeButton" onclick="self:close()" >Close</button>
   </div>
 
 </window>

--- a/modules/game_questlog/game_questlog.lua
+++ b/modules/game_questlog/game_questlog.lua
@@ -495,7 +495,6 @@ function show()
     if not questLogController.ui then
         return
     end
-    questLogController.ui:centerIn('parent')
     g_game.requestQuestLog()
     questLogController.ui:show()
     questLogController.ui:raise()

--- a/modules/game_rewardwall/game_rewardwall.css
+++ b/modules/game_rewardwall/game_rewardwall.css
@@ -134,8 +134,14 @@
 }
 
 .premium-panel {
-  height: 35px;
+  height: 55px;
   width: 22px;
+  --image-source: /images/ui/2pixel_up_frame_borderimage; 
+  --image-border: 3; 
+  --text-offset: 15 -15;
+  text-wrap: true; 
+  padding: 10 10 10 10;
+  display: block; 
 }
 
 .info-label {
@@ -220,3 +226,15 @@
   width: 60px;
   height: 70px;
 }
+
+
+.bottom-panel { 
+  text-wrap: true; 
+  --image-source: /images/ui/2pixel_up_frame_borderimage; 
+  --image-border: 3; 
+  display: block; 
+  margin-top: 10px; 
+  height: 95px; 
+  width: 100%; 
+  --text-offset: 10 2;
+ }

--- a/modules/game_rewardwall/game_rewardwall.html
+++ b/modules/game_rewardwall/game_rewardwall.html
@@ -82,17 +82,17 @@
   </div>
 
   <!-- Premium Status Panel -->
-  <QtPanel id="premiumStatus" class="premium-panel">
+  <div id="premiumStatus" class="premium-panel">
     <pre id="premiumMessage" placement="top-left" class="info-label premium-info2" text="Great! You benefit from the best possible rewards and bonuses due to your premium status."></pre>
     <BigPremiumButton id="premiumButton" class="premium-button" onclick="self:onClickSendStoreRewardWall()">
     </BigPremiumButton>
-  </QtPanel>
+  </div>
 
   <!-- Info Hover Panel -->
-  <QtPanel id="infoPanel" class="info-label infoPanel">
+  <div id="infoPanel" class="bottom-panel">
     <label id="free" placement="top-left" class="free-info"></label>
     <label id="premium" class="premium-info"></label>
-  </QtPanel>
+  </div>
   <hr id="footerSeparator" class="footer-separator"/>
 
   <!-- Footer Panel -->

--- a/modules/game_rewardwall/game_rewardwall.html
+++ b/modules/game_rewardwall/game_rewardwall.html
@@ -1,6 +1,6 @@
 <link href="game_rewardwall.css" />
 <html>
-<window id="rewardWallWindow" anchor="parent" class="reward-wall-window" title="Reward Wall"
+<window id="rewardWallWindow" placement="center" class="reward-wall-window" title="Reward Wall"
   onescape="self:onClickToggle()" layout="type: verticalBox;spacing:5">
   <!-- History Panel -->
   <div id="historyPanel" title="History" class="history-panel minipanel" *visible="false">
@@ -11,12 +11,12 @@
   <div id="restingAreaPanel" title="Resting Area Bonuses" class="content-panel minipanel" focusable="false">
     <div id="restingAreaInfo" layout="type: verticalBox;spacing:5" class="resting-area-info">
       <img src="/game_rewardwall/images/icon-rewardstreak-default" id="rewardStreakIcon" class="resting-area-icon"
-        onhover="self:onhoverStatusPlayer(event)" text="2" style="text-offset:25 13" />
+        onhover="self:onhoverStatusPlayer(event)" text="2" style="text-offset:30 -7" />
       <div id="timeLeft" class="resting-area-time" onhover="self:onhoverStatusPlayer(event)" ></div>
       <GoldLabel2 id="restingAreaGold" class="resting-area-gold" onhover="self:onhoverStatusPlayer(event)"></GoldLabel2>
     </div>
 
-    <div id="bonusIcons" anchor="parent" layout="type: horizontalBox;spacing:4" class="bonus-icons-container" focusable="false">
+    <div id="bonusIcons" placement="top-left" layout="type: horizontalBox;spacing:4" class="bonus-icons-container" focusable="false">
       <div class="imgBonuses imgBonusesCss" id="bonusIcon1" onhover="self:onhoverBonus(event)"></div>
       <div class="imgBonuses imgBonusesCss" id="bonusIcon2" onhover="self:onhoverBonus(event)"></div>
       <div class="imgBonuses imgBonusesCss" id="bonusIcon3" onhover="self:onhoverBonus(event)"></div>
@@ -83,21 +83,21 @@
 
   <!-- Premium Status Panel -->
   <QtPanel id="premiumStatus" class="premium-panel">
-    <pre id="premiumMessage" anchor="parent" class="info-label premium-info2" text="Great! You benefit from the best possible rewards and bonuses \n due to your premium status."></pre>
+    <pre id="premiumMessage" placement="top-left" class="info-label premium-info2" text="Great! You benefit from the best possible rewards and bonuses due to your premium status."></pre>
     <BigPremiumButton id="premiumButton" class="premium-button" onclick="self:onClickSendStoreRewardWall()">
     </BigPremiumButton>
   </QtPanel>
 
   <!-- Info Hover Panel -->
   <QtPanel id="infoPanel" class="info-label infoPanel">
-    <label id="free" anchor="parent" class="free-info"></label>
+    <label id="free" placement="top-left" class="free-info"></label>
     <label id="premium" class="premium-info"></label>
   </QtPanel>
   <hr id="footerSeparator" class="footer-separator"/>
 
   <!-- Footer Panel -->
-  <div id="footerPanel" class="footer-panel" anchor="parent" focusable="false">
-    <GoldLabel2 id="footerGold1" anchor="parent" class="footer-gold-1"></GoldLabel2>
+  <div id="footerPanel" class="footer-panel" placement="top-left" focusable="false">
+    <GoldLabel2 id="footerGold1" placement="top-left" class="footer-gold-1"></GoldLabel2>
     <GoldLabel2 id="footerGold2" class="footer-gold-2"> </GoldLabel2>
     <MiniPremiumButton id="instantRewardButton" class="instant-reward-button"
       onclick="self:onClickbuyInstantRewardAccess()"></MiniPremiumButton>

--- a/modules/game_rewardwall/game_rewardwall.lua
+++ b/modules/game_rewardwall/game_rewardwall.lua
@@ -396,7 +396,6 @@ function show()
     rewardWallController.ui:show()
     rewardWallController.ui:raise()
     rewardWallController.ui:focus()
-    rewardWallController.ui:centerIn('parent')
     connectOnServerError()
     premiumStatusWindwos(g_game.getLocalPlayer():isPremium())
 end

--- a/modules/game_rewardwall/game_rewardwall.lua
+++ b/modules/game_rewardwall/game_rewardwall.lua
@@ -489,9 +489,11 @@ end
 -- =============================================*/
 function rewardWallController:onClickshowHistory()
     visibleHistory(not rewardWallController.ui.historyPanel:isVisible())
-    g_game.requestOpenRewardHistory()
+    if rewardWallController.ui.historyPanel:isVisible() then
+        g_game.requestOpenRewardHistory()
+    end
     rewardWallController.ui.footerPanel.historyButton:setText(
-        rewardWallController.ui.historyPanel:isVisible() and "back" or "history")
+    rewardWallController.ui.historyPanel:isVisible() and "back" or "history")
 end
 
 function rewardWallController:onClickToggle()


### PR DESCRIPTION
# Description

# this pr:
<img width="647" height="460" alt="image" src="https://github.com/user-attachments/assets/1c95e28f-ce92-4f0a-8d8e-f2423496b6dc" />

<img width="570" height="545" alt="image" src="https://github.com/user-attachments/assets/a97ac338-a88d-4707-b305-23711145960a" />
<img width="825" height="671" alt="image" src="https://github.com/user-attachments/assets/01226f7e-383d-4de5-929e-5975b5805005" />


----------
----------
----------
----------
----------
# main repo:

<img width="817" height="952" alt="image" src="https://github.com/user-attachments/assets/0c262fd7-f975-4d1e-8bdd-74601acb1c9f" />
<img width="580" height="551" alt="image" src="https://github.com/user-attachments/assets/de968d1d-f5ec-4aa9-84d1-c48adacdafd4" />
<img width="640" height="466" alt="image" src="https://github.com/user-attachments/assets/4cf98f69-f1dd-4239-a294-2a6e95a66ac5" />
