### PR TITLE
fix: properly unbind hotkeys when clearing slots

### DIFF
--- a/modules/game_actionbar/game_actionbar.lua
+++ b/modules/game_actionbar/game_actionbar.lua
@@ -352,6 +352,9 @@ end
 
 function clearSlot()
     local slot = actionBarPanel:getChildById(slotToEdit)
+    if slot.hotkey and slot.hotkey ~= '' then  
+        g_keyboard.unbindKeyPress(slot.hotkey)  
+    end  
     slot:setImageSource('/images/game/actionbar/slot-actionbar')
     slot:setImageClip('0 0 0 0')
     slot:clearItem()
@@ -365,10 +368,17 @@ function clearSlot()
     slot:getChildById('tier'):setVisible(false)
     slot:getChildById('text'):setText('')
     slot:setTooltip('')
+    slot.hotkey = nil    
+    slot:getChildById('key'):setText('')  
+    setupHotkeys()  
+    saveActionBar()
 end
 
 function clearSlotById(slotId)
     local slot = actionBarPanel:getChildById(slotId)
+    if slot.hotkey and slot.hotkey ~= '' then  
+        g_keyboard.unbindKeyPress(slot.hotkey)  
+    end    
     slot:setImageSource('/images/game/actionbar/slot-actionbar')
     slot:setImageClip('0 0 0 0')
     slot:clearItem()
@@ -382,6 +392,10 @@ function clearSlotById(slotId)
     slot:getChildById('tier'):setVisible(false)
     slot:getChildById('text'):setText('')
     slot:setTooltip('')
+    slot.hotkey = nil    
+    slot:getChildById('key'):setText('')  
+    setupHotkeys()  
+    saveActionBar()
 end
 
 function clearHotkey()
@@ -786,7 +800,7 @@ function hotkeyClear(assignWindow)
     comboPreview:setText(tr('Current hotkey to change: none'))
     comboPreview.keyCombo = ''
     comboPreview:resizeToText()
-    assignWindow:getChildById('applyButton'):disable()
+    assignWindow:getChildById('applyButton'):enable()
 end
 
 function hotkeyCaptureOk(assignWindow, keyCombo)
@@ -799,15 +813,23 @@ function hotkeyCaptureOk(assignWindow, keyCombo)
             end
         end
     end
-    unbindHotkeys()
-    slot.hotkey = keyCombo
-    local text = slot.hotkey
-    text = text:gsub('Shift', 'S')
-    text = text:gsub('Alt', 'A')
-    text = text:gsub('Ctrl', 'C')
-    text = text:gsub('+', '')
-    slot:getChildById('key'):setText(text)
+    if slot.hotkey and slot.hotkey ~= '' then  
+        g_keyboard.unbindKeyPress(slot.hotkey)  
+    end
+    if keyCombo == '' then  
+        slot.hotkey = nil  
+        slot:getChildById('key'):setText('')  
+    else  
+        slot.hotkey = keyCombo  
+        local text = slot.hotkey  
+        text = text:gsub('Shift', 'S')  
+        text = text:gsub('Alt', 'A')  
+        text = text:gsub('Ctrl', 'C')  
+        text = text:gsub('+', '')  
+        slot:getChildById('key'):setText(text)  
+    end 
     setupHotkeys()
+    saveActionBar()
     if assignWindow == editHotkeyWindow then
         closeEditHotkeyWindow()
         return


### PR DESCRIPTION
# Description  
  
Fixes a bug where hotkeys remained active after clearing actionbar slots. The hotkey would persist even when the slot content was cleared, and would automatically reappear when adding new content to the slot.  
  
## Behavior  
  
### **Actual**  
  
1. Set an action/spell/item in a slot  
2. Assign a hotkey to it (e.g., F1)  
3. Clear the slot via menu or by adding new content  
4. Add new content without setting a hotkey  
5. The old hotkey (F1) is still active and bound to the slot  


https://github.com/user-attachments/assets/d5d8514e-fe8d-4db0-9740-71c36360fc57

Additionally, in the hotkey setup window, clicking "Clear" would disable the "Apply" button, preventing users from clearing hotkeys.  
  
### **Expected**  
  
1. Set an action/spell/item in a slot  
2. Assign a hotkey to it (e.g., F1)  
3. Clear the slot via menu or by adding new content  
4. Add new content without setting a hotkey  
5. No hotkey is bound to the slot  
 

https://github.com/user-attachments/assets/ff515a42-87d0-4a19-912c-3b871d550d4c

In the hotkey setup window, clicking "Clear" and then "Apply" should successfully remove the hotkey.  
  
## Fixes  
  
Fixes hotkey persistence bug in actionbar module  
  
## Type of change  
  
- [x] Bug fix (non-breaking change which fixes an issue)  
- [ ] New feature (non-breaking change which adds functionality)  
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)  
- [ ] This change requires a documentation update  
  
## How Has This Been Tested  
  
- [x] Clear slot via right-click menu removes hotkey completely  
- [x] Adding new content to a slot doesn't retain old hotkey  
- [x] Clear hotkey via setup window works correctly  
- [x] Hotkeys persist correctly after client restart  
  
**Test Configuration**:  
  
- Server Version: N/A (client-side only)  
- Client: OTClient (main branch)
- Operating System: Windows 10
  
## Checklist  
  
- [x] My code follows the style guidelines of this project  
- [x] I have performed a self-review of my own code  
- [x] I checked the PR checks reports  
- [x] I have commented my code, particularly in hard-to-understand areas  
- [ ] I have made corresponding changes to the documentation  
- [x] My changes generate no new warnings  
- [x] I have added tests that prove my fix is effective or that my feature works