### PR TITLE
handle wheel packet properly

### DIFF
--- a/src/client/protocolcodes.h
+++ b/src/client/protocolcodes.h
@@ -83,6 +83,7 @@ namespace Proto
         // original tibia ONLY
         GameServerImbuementDurations = 93,
         GameServerPassiveCooldown = 94,
+        GameServerWheelOfDestiny = 95,
         GameServerBosstiaryData = 97,
         GameServerBosstiarySlots = 98,
         GameServerSendClientCheck = 99,

--- a/src/client/protocolgame.h
+++ b/src/client/protocolgame.h
@@ -319,6 +319,7 @@ private:
     void parsePartyAnalyzer(const InputMessagePtr& msg);
     void parseImbuementDurations(const InputMessagePtr& msg);
     void parsePassiveCooldown(const InputMessagePtr& msg);
+    void parseWheelOfDestiny(const InputMessagePtr& msg);
     void parseClientCheck(const InputMessagePtr& msg);
     void parseGameNews(const InputMessagePtr& msg);
     void parseBlessDialog(const InputMessagePtr& msg);

--- a/src/client/protocolgameparse.cpp
+++ b/src/client/protocolgameparse.cpp
@@ -4501,14 +4501,14 @@ void ProtocolGame::parseWheelOfDestiny(const InputMessagePtr& msg)
 
     // grade modifiers for all vocations
     listSize = msg->getU8();
-    for (int i = 0; i < listSize; i++) {
+    for (uint16_t i = 0; i < listSize; i++) {
         msg->getU8(); // key
         msg->getU8(); // value
     }
 
     // grade modifiers for vocation of currently viewed player
     listSize = msg->getU8();
-    for (int i = 0; i < listSize; i++) {
+    for (uint16_t i = 0; i < listSize; i++) {
         msg->getU8(); // key
         msg->getU8(); // value
     }


### PR DESCRIPTION
# Description

Currently the wheel of destiny is not implemented.
The wheel packet is being sent on startup.
This breaks the communication for me on 13.20.
This commit fixes that problem by adding code that reads this packet.

**Possible problem:**
I am not sure when was "the way of the monk" added to the wheel of destiny packet.
I know that monk was added in 15.00, but at the time of figuring out the packet, I only had client 15.11 to test, so correct me if ">1500" is wrong in that version check.

## Type of change
  - [x] Bug fix (non-breaking change which fixes an issue)
  - [ ] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [ ] This change requires a documentation update

## How Has This Been Tested

I connected to a 13.20 server (tfs-based) with both regular client and otcr. The server has been online for over 3 years using the regular client so I am very certain of server side packet structure being correct.

## Checklist

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [x] I checked the PR checks reports
  - [x] I have commented my code, particularly in hard-to-understand areas
  - [ ] I have made corresponding changes to the documentation
  - [x] My changes generate no new warnings
  - [ ] I have added tests that prove my fix is effective or that my feature works
