### PR TITLE
fix: classic controls - right/left click not opening depot/chests

### DIFF
--- a/modules/game_interface/gameinterface.lua
+++ b/modules/game_interface/gameinterface.lua
@@ -1123,6 +1123,10 @@ function processMouseAction(menuPosition, mouseButton, autoWalkPos, lookThing, u
                             -- For pickupable containers like quivers, backpacks, etc., open them instead of quicklooting
                             g_game.open(useThing)
                             return true
+						elseif table.find({3497, 3498, 3499, 3500, 3502, 12902}, useThing:getId()) then
+                            -- For depot chests, lockers, depot boxes, inbox, etc., always open them
+                            g_game.open(useThing)
+                            return true
                         elseif g_game.getFeature(GameThingQuickLoot) and modules.game_quickloot then
                             -- For containers in the world, quickloot
                             g_game.sendQuickLoot(1, useThing)
@@ -1226,7 +1230,11 @@ function processMouseAction(menuPosition, mouseButton, autoWalkPos, lookThing, u
                     -- ONLY quickloot containers/corpses in the game world
                     if (useThing:isContainer() or useThing:isLyingCorpse()) and not useThing:getParentContainer() then
                         -- Only handle containers that are in the game world (not in inventory)
-                        if g_game.getFeature(GameThingQuickLoot) and modules.game_quickloot then
+                        if table.find({3497, 3498, 3499, 3500, 3502, 12902}, useThing:getId()) then
+                            -- For depot chests, lockers, depot boxes, inbox, etc., always open them
+                            g_game.open(useThing)
+                            return true
+                        elseif g_game.getFeature(GameThingQuickLoot) and modules.game_quickloot then
                             g_game.sendQuickLoot(1, useThing)
                             return true
                         else


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Behavior

### **Actual**

Do this and that doesn't happens

### **Expected**

Do this and that happens

## Fixes

\# (issue)

## Type of change

Please delete options that are not relevant.

  - [X] Bug fix (non-breaking change which fixes an issue)
  - [ ] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [ ] This change requires a documentation update

**Test Configuration**:

  - Server Version: Canary 1412
  - Client: OTCr
  - Operating System: W11

## Checklist

  - [X] My code follows the style guidelines of this project
  - [X] I have performed a self-review of my own code
  - [X] I checked the PR checks reports
  - [X] I have commented my code, particularly in hard-to-understand areas
  - [X] I have made corresponding changes to the documentation
  - [X] My changes generate no new warnings
  - [X] I have added tests that prove my fix is effective or that my feature works
