### PR TITLE
fix: support 1fps

### DIFF
--- a/modules/client_options/styles/graphics/graphics.otui
+++ b/modules/client_options/styles/graphics/graphics.otui
@@ -53,7 +53,7 @@ UIWidget
       !text: tr('Game framerate limit: %s', 'max')
       anchors.top: prev.bottom
       margin-top: 5
-      &minimumScrollValue: 10
+      &minimumScrollValue: 1
       &maximumScrollValue: 501
       &scrollSize: 21
       @onSetup: |

--- a/src/framework/core/adaptativeframecounter.cpp
+++ b/src/framework/core/adaptativeframecounter.cpp
@@ -29,7 +29,7 @@ bool AdaptativeFrameCounter::update()
     if (maxFps > 0) {
         const int32_t sleepPeriod = (getMaxPeriod(maxFps) - 1000) - m_timer.elapsed_micros();
         if (sleepPeriod > 0)
-            stdext::microsleep(std::min<int32_t>(sleepPeriod, DrawPool::FPS10 * 1000));
+            stdext::microsleep(std::min<int32_t>(sleepPeriod, DrawPool::FPS1 * 1000));
     }
 
     m_timer.restart();

--- a/src/framework/graphics/drawpool.h
+++ b/src/framework/graphics/drawpool.h
@@ -75,6 +75,7 @@ class DrawPool
 {
 public:
     static constexpr uint16_t
+        FPS1 = 1000 / 1,
         FPS10 = 1000 / 10,
         FPS20 = 1000 / 20,
         FPS60 = 1000 / 60;


### PR DESCRIPTION
# Description

support 1fps. the previous minimum is 10fps. hope it can save cpu.

I am afk cavebotting on cpu-constrained VPS servers.

## Behavior
trying to set target fps to 1
### **Actual**
target fps gets set to 10

### **Expected**
target fps gets set to 1

## Fixes

https://github.com/mehah/otclient/issues/1416

## Type of change

  - [x] New feature (non-breaking change which adds functionality)
## How Has This Been Tested

This has not been tested at all, sorry. Currently unable to compile mehah/otclient

  - Server Version:
  - Client: 4.0b4 (client protocol 7.6)
  - Operating System: Windows 10

## Checklist

  - [ ] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [ ] I checked the PR checks reports
  - [ ] I have commented my code, particularly in hard-to-understand areas
  - [ ] I have made corresponding changes to the documentation
  - [ ] My changes generate no new warnings
  - [ ] I have added tests that prove my fix is effective or that my feature works
