### PR TITLE
feat: function OutputMessage:addBytes

### DIFF
--- a/meta.lua
+++ b/meta.lua
@@ -5791,6 +5791,9 @@ function OutputMessage:addU64(value) end
 ---@param value string
 function OutputMessage:addString(value) end
 
+---@param value string
+function OutputMessage:addBytes(value) end
+
 ---@param bytes integer
 ---@param byte integer
 function OutputMessage:addPaddingBytes(bytes, byte) end

--- a/src/framework/luafunctions.cpp
+++ b/src/framework/luafunctions.cpp
@@ -1024,6 +1024,7 @@ void Application::registerLuaFunctions()
     g_lua.bindClassMemberFunction<OutputMessage>("addU32", &OutputMessage::addU32);
     g_lua.bindClassMemberFunction<OutputMessage>("addU64", &OutputMessage::addU64);
     g_lua.bindClassMemberFunction<OutputMessage>("addString", &OutputMessage::addString);
+    g_lua.bindClassMemberFunction<OutputMessage>("addBytes", &OutputMessage::addBytes);
     g_lua.bindClassMemberFunction<OutputMessage>("addPaddingBytes", &OutputMessage::addPaddingBytes);
     g_lua.bindClassMemberFunction<OutputMessage>("encryptRsa", &OutputMessage::encryptRsa);
     g_lua.bindClassMemberFunction<OutputMessage>("getMessageSize", &OutputMessage::getMessageSize);

--- a/src/framework/net/outputmessage.cpp
+++ b/src/framework/net/outputmessage.cpp
@@ -93,6 +93,15 @@ void OutputMessage::addString(const std::string_view buffer)
     m_messageSize += len;
 }
 
+void OutputMessage::addBytes(const std::string_view buffer)
+{
+    const int len = buffer.length();
+    checkWrite(len);
+    memcpy(m_buffer + m_writePos, buffer.data(), len);
+    m_writePos += len;
+    m_messageSize += len;
+}
+
 void OutputMessage::addPaddingBytes(const int bytes, const uint8_t byte)
 {
     if (bytes <= 0)

--- a/src/framework/net/outputmessage.h
+++ b/src/framework/net/outputmessage.h
@@ -47,6 +47,7 @@ public:
     void addU32(uint32_t value);
     void addU64(uint64_t value);
     void addString(std::string_view buffer);
+    void addBytes(std::string_view buffer);
     void addPaddingBytes(int bytes, uint8_t byte = 0);
     void prependU8(uint8_t value);
     void prependU16(uint16_t value);


### PR DESCRIPTION
# Description

add a lua function OutputMessage:addBytes.
Motivation: simplify recorded-packet scripts like
```lua
    local msg = OutputMessage.create()
    msg:addU8(15)
    msg:addU8(0)
    msg:addU8(120)
    msg:addU8(255)
    msg:addU8(255)
    msg:addU8(65)
    msg:addU8(0)
    msg:addU8(0)
    msg:addU8(129)
    msg:addU8(12)
    msg:addU8(0)
    msg:addU8(230)
    msg:addU8(3)
    msg:addU8(109)
    msg:addU8(4)
    msg:addU8(7)
    msg:addU8(1)
    g_game.getProtocolGame().send(msg)
```
with:
```lua
    local msg = OutputMessage.create()
    msg:addBytes("\x0F\x00\x78\xFF\xFF\x41\x00\x00\x81\x0C\x00\xE6\x03\x6D\x04\x07\x01")
    g_game.getProtocolGame().send(msg)
```

## Behavior

### **Actual**


### **Expected**

## Fixes

\# (issue)

## Type of change

Please delete options that are not relevant.

  - [x] New feature (non-breaking change which adds functionality)
  - [ ] This change requires a documentation update

## How Has This Been Tested

This has not been tested directly, as I currently cannot compile mehah/otclient,
*but* I did add this to edubart/otclient in 2024: https://github.com/edubart/otclient/pull/1218
and in edubart/otclient, it was tested. Also, the implementation is trivial, so I am confident it works.
**Test Configuration**:

  - Server Version:
  - Client:
  - Operating System:

## Checklist

  - [ ] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [x] I checked the PR checks reports
  - [ ] I have commented my code, particularly in hard-to-understand areas
  - [ ] I have made corresponding changes to the documentation
  - [ ] My changes generate no new warnings
  - [ ] I have added tests that prove my fix is effective or that my feature works
