### PR TITLE
improve: android features and fixes

### DIFF
--- a/android/app/src/main/java/com/otclient/AndroidManager.kt
+++ b/android/app/src/main/java/com/otclient/AndroidManager.kt
@@ -5,12 +5,19 @@ import android.os.Handler
 import android.os.Looper
 import android.view.View
 import android.view.inputmethod.InputMethodManager
+import android.widget.TextView
+import androidx.core.view.isVisible
 
 class AndroidManager(
     private val context: Context,
     private val editText: FakeEditText,
+    private val previewContainer: View,
+    private val previewText: TextView,
 ) {
     private val handler = Handler(Looper.getMainLooper())
+    private var isImeVisible = false
+    private var shouldShowPreview = false
+    private var pendingPreviewText: String = ""
 
     /*
      * Methods called from JNI
@@ -30,6 +37,41 @@ class AndroidManager(
             editText.visibility = View.INVISIBLE
             val imm = editText.context.getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager
             imm.hideSoftInputFromWindow(editText.windowToken, 0)
+            hidePreviewInternal(clearText = false)
+        }
+    }
+
+    fun showInputPreview(text: String) {
+        handler.post {
+            pendingPreviewText = text
+            shouldShowPreview = true
+            if (isImeVisible) showPreviewInternal()
+        }
+    }
+
+    fun updateInputPreview(text: String) {
+        handler.post {
+            pendingPreviewText = text
+            if (shouldShowPreview && isImeVisible) showPreviewInternal(animate = false)
+        }
+    }
+
+    fun hideInputPreview() {
+        handler.post {
+            shouldShowPreview = false
+            pendingPreviewText = ""
+            hidePreviewInternal(clearText = true)
+        }
+    }
+
+    fun onImeVisibilityChanged(visible: Boolean) {
+        handler.post {
+            isImeVisible = visible
+            if (visible) {
+                if (shouldShowPreview) showPreviewInternal()
+            } else {
+                hidePreviewInternal(clearText = false)
+            }
         }
     }
 
@@ -37,4 +79,48 @@ class AndroidManager(
 
     external fun nativeInit()
     external fun nativeSetAudioEnabled(enabled: Boolean)
+
+    private fun showPreviewInternal(animate: Boolean = true) {
+        previewContainer.animate().cancel()
+        previewText.text = pendingPreviewText
+        if (!previewContainer.isVisible) {
+            previewContainer.alpha = if (animate) 0f else 1f
+            previewContainer.isVisible = true
+            if (animate) {
+                previewContainer.animate()
+                    .alpha(1f)
+                    .setDuration(120L)
+                    .start()
+            }
+        } else if (animate) {
+            previewContainer.animate()
+                .alpha(1f)
+                .setDuration(120L)
+                .start()
+        }
+    }
+
+    private fun hidePreviewInternal(animate: Boolean = true, clearText: Boolean) {
+        previewContainer.animate().cancel()
+        if (!previewContainer.isVisible) {
+            if (clearText) previewText.text = ""
+            return
+        }
+
+        if (animate) {
+            previewContainer.animate()
+                .alpha(0f)
+                .setDuration(120L)
+                .withEndAction {
+                    previewContainer.isVisible = false
+                    previewContainer.alpha = 1f
+                    if (clearText) previewText.text = ""
+                }
+                .start()
+        } else {
+            previewContainer.alpha = 1f
+            previewContainer.isVisible = false
+            if (clearText) previewText.text = ""
+        }
+    }
 }

--- a/android/app/src/main/java/com/otclient/MainActivity.kt
+++ b/android/app/src/main/java/com/otclient/MainActivity.kt
@@ -2,6 +2,7 @@ package com.otclient
 
 import android.os.Bundle
 import android.view.ViewGroup
+import androidx.core.view.ViewCompat
 import androidx.core.view.WindowCompat
 import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.WindowInsetsControllerCompat
@@ -20,9 +21,23 @@ class MainActivity : GameActivity() {
         androidManager = AndroidManager(
             context = this,
             editText = binding.editText,
+            previewContainer = binding.keyboardPreviewContainer,
+            previewText = binding.inputPreviewText,
         ).apply {
             nativeInit()
             nativeSetAudioEnabled(true)
+        }
+
+        var lastImeVisible = false
+        ViewCompat.setOnApplyWindowInsetsListener(binding.keyboardPreviewContainer) { view, insets ->
+            val imeInsets = insets.getInsets(WindowInsetsCompat.Type.ime())
+            val imeVisible = imeInsets.bottom > 0
+            if (imeVisible != lastImeVisible) {
+                lastImeVisible = imeVisible
+                androidManager.onImeVisibilityChanged(imeVisible)
+            }
+            view.translationY = -imeInsets.bottom.toFloat()
+            insets
         }
 
         hideSystemBars()

--- a/android/app/src/main/java/com/otclient/NativeInputConnection.kt
+++ b/android/app/src/main/java/com/otclient/NativeInputConnection.kt
@@ -12,9 +12,12 @@ class NativeInputConnection(
     override fun sendKeyEvent(event: KeyEvent): Boolean {
         val keyCode = event.keyCode
         if (event.action == KeyEvent.ACTION_DOWN) {
-            if (event.isPrintingKey) {
-                commitText(event.unicodeChar.toChar().toString(), 1)
+            val text = when {
+                event.isPrintingKey -> event.unicodeChar.toChar().toString()
+                keyCode == KeyEvent.KEYCODE_SPACE -> " "
+                else -> null
             }
+            if (text != null) commitText(text, 1)
             targetView.onNativeKeyDown(keyCode)
             return true
         } else if (event.action == KeyEvent.ACTION_UP) {

--- a/android/app/src/main/res/layout/activity_main.xml
+++ b/android/app/src/main/res/layout/activity_main.xml
@@ -6,7 +6,36 @@
     <com.otclient.FakeEditText
         android:id="@+id/editText"
         android:layout_width="wrap_content"
+        android:layout_height="wrap_content" />
+
+    <LinearLayout
+        android:id="@+id/keyboardPreviewContainer"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
-         />
+        android:layout_gravity="bottom"
+        android:gravity="center_horizontal"
+        android:orientation="vertical"
+        android:paddingStart="16dp"
+        android:paddingTop="12dp"
+        android:paddingEnd="16dp"
+        android:paddingBottom="24dp"
+        android:visibility="gone">
+
+        <TextView
+            android:id="@+id/inputPreviewText"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:background="@drawable/keyboard_preview_background"
+            android:elevation="6dp"
+            android:maxLines="2"
+            android:minWidth="120dp"
+            android:paddingStart="16dp"
+            android:paddingTop="8dp"
+            android:paddingEnd="16dp"
+            android:paddingBottom="8dp"
+            android:textColor="@android:color/white"
+            android:textSize="16sp"
+            android:textStyle="bold" />
+    </LinearLayout>
 
 </FrameLayout>

--- a/data/fonts/verdana-9px.otfont
+++ b/data/fonts/verdana-9px.otfont
@@ -1,6 +1,6 @@
 Font
   name: Verdana-9px
-  texture: Verdana-9px
+  texture: verdana-9px
   height: 13
   glyph-size: 13 13
   space-width: 3

--- a/mods/game_bot/default_configs/cavebot_1.3/storage.json
+++ b/mods/game_bot/default_configs/cavebot_1.3/storage.json
@@ -116,7 +116,7 @@
     "on": false
   },
   "manaShield": "utamo vita",
-  "autoTradeMessage": "I'm using OTClientV8!",
+  "autoTradeMessage": "I'm using OTClient Redemption!",
   "antiParalyze": "utani hur",
   "manaTrain": {
     "max": 100,

--- a/mods/game_bot/default_configs/cavebot_1.3/tools.lua
+++ b/mods/game_bot/default_configs/cavebot_1.3/tools.lua
@@ -144,7 +144,7 @@ macro(60000, "Send message on trade", function()
     sayChannel(trade, storage.autoTradeMessage)
   end
 end)
-UI.TextEdit(storage.autoTradeMessage or "I'm using OTClientV8!", function(widget, text)
+UI.TextEdit(storage.autoTradeMessage or "I'm using OTClient Redemption!", function(widget, text)
   storage.autoTradeMessage = text
 end)
 

--- a/mods/game_bot/default_configs/vBot_4.8/vBot/tools.lua
+++ b/mods/game_bot/default_configs/vBot_4.8/vBot/tools.lua
@@ -39,7 +39,7 @@ macro(60000, "Send message on trade", function()
     sayChannel(trade, storage.autoTradeMessage)
   end
 end)
-UI.TextEdit(storage.autoTradeMessage or "I'm using OTClientV8!", function(widget, text)
+UI.TextEdit(storage.autoTradeMessage or "I'm using OTClient Redemption!", function(widget, text)
   storage.autoTradeMessage = text
 end)
 

--- a/mods/game_bot/functions/player_conditions.lua
+++ b/mods/game_bot/functions/player_conditions.lua
@@ -4,7 +4,7 @@ for i, state in ipairs(PlayerStates) do
   context[state] = state
 end
 
-context.hasCondition = function(condition) return bit.band(context.player:getStates(), condition) > 0 end
+context.hasCondition = function(condition) return Bit.band(context.player:getStates(), condition) > 0 end
 
 context.isPoisioned = function() return context.hasCondition(PlayerStates.Poison) end
 context.isBurning = function() return context.hasCondition(PlayerStates.Burn) end

--- a/mods/game_bot/panels/tools.lua
+++ b/mods/game_bot/panels/tools.lua
@@ -11,7 +11,7 @@ Panels.TradeMessage = function(parent)
       context.sayChannel(trade, context.storage.autoTradeMessage)
     end
   end, parent)
-  context.addTextEdit("autoTradeMessage", context.storage.autoTradeMessage or "I'm using OTClientV8 - https://github.com/OTCv8/otclientv8", function(widget, text)
+  context.addTextEdit("autoTradeMessage", context.storage.autoTradeMessage or "I'm using OTClient Redemption - https://github.com/mehah/otclient", function(widget, text)
     context.storage.autoTradeMessage = text
   end, parent)
 end

--- a/modules/game_battle/battle.lua
+++ b/modules/game_battle/battle.lua
@@ -2327,54 +2327,56 @@ function onCreatureHealthPercentChange(creature, healthPercent, oldHealthPercent
             if battleButton.data then
                 battleButton.data.healthpercent = healthPercent
             end
+            local skipInstance = false
             if sortType == 'health' then
                 if healthPercent == oldHealthPercent then
-                    goto continue -- Skip this instance
+                    skipInstance = true -- Skip this instance
                 end
-                if healthPercent == 0 then
-                    goto continue -- Let onCreatureDisappear handle this
+                if not skipInstance and healthPercent == 0 then
+                    skipInstance = true -- Let onCreatureDisappear handle this
                 end
 
-                local index = binarySearch(instance.binaryTree, {
-                    healthpercent = oldHealthPercent,
-                    id = creatureId
-                }, BSComparatorSortType, 'health', true)
-                if index ~= nil and creatureId == instance.binaryTree[index].id then
-                    instance.binaryTree[index].healthpercent = healthPercent
-                    battleButton.data.healthpercent = healthPercent
-                    if healthPercent > oldHealthPercent then
-                        if index < #instance.binaryTree then
-                            for i = index, #instance.binaryTree - 1 do
-                                local a = instance.binaryTree[i]
-                                local b = instance.binaryTree[i + 1]
-                                if a.healthpercent > b.healthpercent or (a.healthpercent == b.healthpercent and a.id > b.id) then
-                                    local tmp = instance.binaryTree[i]
-                                    instance.binaryTree[i] = instance.binaryTree[i + 1]
-                                    instance.binaryTree[i + 1] = tmp
+                if not skipInstance then
+                    local index = binarySearch(instance.binaryTree, {
+                        healthpercent = oldHealthPercent,
+                        id = creatureId
+                    }, BSComparatorSortType, 'health', true)
+                    if index ~= nil and creatureId == instance.binaryTree[index].id then
+                        instance.binaryTree[index].healthpercent = healthPercent
+                        battleButton.data.healthpercent = healthPercent
+                        if healthPercent > oldHealthPercent then
+                            if index < #instance.binaryTree then
+                                for i = index, #instance.binaryTree - 1 do
+                                    local a = instance.binaryTree[i]
+                                    local b = instance.binaryTree[i + 1]
+                                    if a.healthpercent > b.healthpercent or (a.healthpercent == b.healthpercent and a.id > b.id) then
+                                        local tmp = instance.binaryTree[i]
+                                        instance.binaryTree[i] = instance.binaryTree[i + 1]
+                                        instance.binaryTree[i + 1] = tmp
+                                    end
+                                end
+                            end
+                        else
+                            if index > 1 then
+                                for i = index, 2, -1 do
+                                    local a = instance.binaryTree[i - 1]
+                                    local b = instance.binaryTree[i]
+                                    if a.healthpercent > b.healthpercent or (a.healthpercent == b.healthpercent and a.id > b.id) then
+                                        local tmp = instance.binaryTree[i - 1]
+                                        instance.binaryTree[i - 1] = instance.binaryTree[i]
+                                        instance.binaryTree[i] = tmp
+                                    end
                                 end
                             end
                         end
-                    else
-                        if index > 1 then
-                            for i = index, 2, -1 do
-                                local a = instance.binaryTree[i - 1]
-                                local b = instance.binaryTree[i]
-                                if a.healthpercent > b.healthpercent or (a.healthpercent == b.healthpercent and a.id > b.id) then
-                                    local tmp = instance.binaryTree[i - 1]
-                                    instance.binaryTree[i - 1] = instance.binaryTree[i]
-                                    instance.binaryTree[i] = tmp
-                                end
-                            end
-                        end
+                        instance:correctBattleButtons()
                     end
-                    instance:correctBattleButtons()
                 end
             end
-            if battleButton.creature then
+            if not skipInstance and battleButton.creature then
                 battleButton:update()
             end
         end
-        ::continue::
     end
 end
 

--- a/modules/game_cyclopedia/tab/items/items.lua
+++ b/modules/game_cyclopedia/tab/items/items.lua
@@ -1162,20 +1162,19 @@ function Cyclopedia.Items.sendPartyLootItems()
     
     local totalList = {}
     for i, category in pairs(Cyclopedia.ItemList) do
-        if i == 1000 or i == 30 then -- Skip WeaponsAll and Gold categories
-            goto continue
-        end
+        local skipCategory = (i == 1000 or i == 30) -- Skip WeaponsAll and Gold categories
 
-        for _, itemInfo in ipairs(category) do
-            if itemInfo then
-                local item = Item.create(itemInfo:getId())
-                if item then
-                    local itemValue = Cyclopedia.Items.getCurrentItemValue(item)
-                    totalList[tonumber(itemInfo:getId())] = itemValue
+        if not skipCategory then
+            for _, itemInfo in ipairs(category) do
+                if itemInfo then
+                    local item = Item.create(itemInfo:getId())
+                    if item then
+                        local itemValue = Cyclopedia.Items.getCurrentItemValue(item)
+                        totalList[tonumber(itemInfo:getId())] = itemValue
+                    end
                 end
             end
         end
-        :: continue ::
     end
 
 	if g_game.sendPartyLootPrice then

--- a/src/framework/platform/androidmanager.cpp
+++ b/src/framework/platform/androidmanager.cpp
@@ -45,6 +45,10 @@ void AndroidManager::setAndroidManager(JNIEnv* env, jobject androidManager) {
     m_midShowSoftKeyboard = jniEnv->GetMethodID(androidManagerJClass, "showSoftKeyboard", "()V");
     m_midHideSoftKeyboard = jniEnv->GetMethodID(androidManagerJClass, "hideSoftKeyboard", "()V");
     m_midGetDisplayDensity = jniEnv->GetMethodID(androidManagerJClass, "getDisplayDensity", "()F");
+    m_midShowInputPreview = jniEnv->GetMethodID(androidManagerJClass, "showInputPreview", "(Ljava/lang/String;)V");
+    m_midUpdateInputPreview = jniEnv->GetMethodID(androidManagerJClass, "updateInputPreview", "(Ljava/lang/String;)V");
+    m_midHideInputPreview = jniEnv->GetMethodID(androidManagerJClass, "hideInputPreview", "()V");
+    jniEnv->DeleteLocalRef(androidManagerJClass);
 }
 
 void AndroidManager::showKeyboardSoft() {
@@ -55,6 +59,25 @@ void AndroidManager::showKeyboardSoft() {
 void AndroidManager::hideKeyboard() {
     JNIEnv* env = getJNIEnv();
     env->CallVoidMethod(m_androidManagerJObject, m_midHideSoftKeyboard);
+}
+
+void AndroidManager::showInputPreview(const std::string& text) {
+    JNIEnv* env = getJNIEnv();
+    jstring jText = env->NewStringUTF(text.c_str());
+    env->CallVoidMethod(m_androidManagerJObject, m_midShowInputPreview, jText);
+    env->DeleteLocalRef(jText);
+}
+
+void AndroidManager::updateInputPreview(const std::string& text) {
+    JNIEnv* env = getJNIEnv();
+    jstring jText = env->NewStringUTF(text.c_str());
+    env->CallVoidMethod(m_androidManagerJObject, m_midUpdateInputPreview, jText);
+    env->DeleteLocalRef(jText);
+}
+
+void AndroidManager::hideInputPreview() {
+    JNIEnv* env = getJNIEnv();
+    env->CallVoidMethod(m_androidManagerJObject, m_midHideInputPreview);
 }
 
 void AndroidManager::unZipAssetData() {

--- a/src/framework/platform/androidmanager.h
+++ b/src/framework/platform/androidmanager.h
@@ -37,6 +37,10 @@ public:
     void showKeyboardSoft();
     void hideKeyboard();
 
+    void showInputPreview(const std::string& text);
+    void updateInputPreview(const std::string& text);
+    void hideInputPreview();
+
     void unZipAssetData();
 
     std::string getStringFromJString(jstring);
@@ -53,6 +57,9 @@ private:
     jmethodID m_midShowSoftKeyboard;
     jmethodID m_midHideSoftKeyboard;
     jmethodID m_midGetDisplayDensity;
+    jmethodID m_midShowInputPreview;
+    jmethodID m_midUpdateInputPreview;
+    jmethodID m_midHideInputPreview;
 };
 
 extern AndroidManager g_androidManager;

--- a/src/framework/platform/androidwindow.cpp
+++ b/src/framework/platform/androidwindow.cpp
@@ -25,6 +25,7 @@
 #include "androidwindow.h"
 #include "androidmanager.h"
 #include <game-activity/native_app_glue/android_native_app_glue.h>
+#include "framework/core/clock.h"
 #include <framework/core/eventdispatcher.h>
 
 AndroidWindow& g_androidWindow = (AndroidWindow&) g_window;

--- a/src/framework/platform/androidwindow.h
+++ b/src/framework/platform/androidwindow.h
@@ -135,6 +135,7 @@ public:
     void onNativeKeyUp(int);
 protected:
     int internalLoadMouseCursor(const ImagePtr& image, const Point& hotSpot);
+    void onDisplayDensityChanged(float newDensity) override;
 private:
     android_app* m_app;
 
@@ -148,6 +149,11 @@ private:
 
     ticks_t m_lastPress = 0;
     bool m_isDragging = false;
+
+    float m_baseDisplayDensity{ DEFAULT_DISPLAY_DENSITY };
+    bool m_hasBaseDisplayDensity{ false };
+
+    void updateDisplayDensityFromSystem(float screenDensity);
 };
 
 extern "C" {

--- a/src/framework/platform/platformwindow.h
+++ b/src/framework/platform/platformwindow.h
@@ -98,7 +98,13 @@ public:
     int getDisplayWidth() { return getDisplaySize().width(); }
     int getDisplayHeight() { return getDisplaySize().height(); }
     float getDisplayDensity() { return m_displayDensity; }
-    void setDisplayDensity(const float v) { m_displayDensity = v; }
+    void setDisplayDensity(const float v) { 
+        if (m_displayDensity == v) {
+            return;
+        }
+        m_displayDensity = v; 
+        onDisplayDensityChanged(v);
+    }
 
     Size getUnmaximizedSize() { return m_unmaximizedSize; }
     Size getSize() { return m_size; }
@@ -133,6 +139,8 @@ public:
 protected:
 
     virtual int internalLoadMouseCursor(const ImagePtr& image, const Point& hotSpot) = 0;
+
+    virtual void onDisplayDensityChanged(float /*newDensity*/) {}
 
     void updateUnmaximizedCoords();
 

--- a/src/framework/ui/uitextedit.cpp
+++ b/src/framework/ui/uitextedit.cpp
@@ -34,6 +34,9 @@
 #include <emscripten/emscripten.h>
 #endif
 #include <framework/platform/platformwindow.h>
+#ifdef ANDROID
+#include <framework/platform/androidmanager.h>
+#endif
 
 UITextEdit::UITextEdit()
 {
@@ -1481,6 +1484,10 @@ bool UITextEdit::onMousePress(const Point& mousePos, const Fw::MouseButton butto
         return true;
 
     if (button == Fw::MouseLeftButton) {
+#ifdef ANDROID
+        if (getProp(PropEditable))
+            g_androidManager.showKeyboardSoft();
+#endif
         const int pos = getTextPos(mousePos);
         if (pos >= 0) {
             const int mods = g_window.getKeyboardModifiers();

--- a/src/framework/ui/uitextedit.h
+++ b/src/framework/ui/uitextedit.h
@@ -108,6 +108,7 @@ protected:
     bool onMouseRelease(const Point& mousePos, Fw::MouseButton button) override;
     bool onMouseMove(const Point& mousePos, const Point& mouseMoved) override;
     bool onDoubleClick(const Point& mousePos) override;
+    void onTextChange(std::string_view text, std::string_view oldText) override;
     virtual void onTextAreaUpdate(const Point& vitualOffset, const Size& visibleSize, const Size& totalSize);
 
 private:


### PR DESCRIPTION
**Android Fixes Summary**

  Display Density
    - Fixed an issue with display density where the client would lose its original reference value when minimized and then restored.

  Text Input Focus
    - UITextEdit now reopens the soft keyboard whenever an editable field is tapped, even if already focused.
    - Added input preview bar above the keyboard (layout + drawable + animations), synchronized with IME visibility and powered by AndroidManager.
	
  Text Entry Improvements
    - Soft keyboard input path rewritten to commit characters reliably, including space (virtual & physical keyboards).
    - Added full support for accented characters/diacritics; native bridge now passes Latin-1 text correctly in both directions so in-game chat and the preview display match typed content.
	
  Lua Compatibility (Android Runtime)
    - Introduced check_load() helper to route dynamic expressions through loadstring on Lua 5.1, fixing quest log/event binding loading.
    - Replaced goto statements (unsupported on Lua 5.1) with flag-based flow in game_battle and Cyclopedia party loot export.
	
  Misc Platform Tweaks
    - Preview text conversion uses UTF-16 bridging so high-byte characters render properly on the Java side.
    - Various Android-specific managers hardened (keyboard show/hide state, preview lifecycle).
	- Typo's
    - All changes verified on Android build: keyboards behave as expected, accented text and spaces preserve properly across UI, and Lua modules load without runtime errors.
    
Feature InputPreview:
![WhatsApp Image 2025-11-08 at 11 14 54](https://github.com/user-attachments/assets/97d4c41c-7755-45fe-8552-c1bdc876bf4a)

Fixed a previously malfunctioning spacebar issue:
![WhatsApp Image 2025-11-08 at 11 14 55](https://github.com/user-attachments/assets/5c26c7fc-6d07-4cec-a00c-6c4f87b2b724)

Special characters and accents now work throughout the Android client:
![WhatsApp Image 2025-11-08 at 11 15 59](https://github.com/user-attachments/assets/6adc55eb-41a2-4194-8464-3fd368c7216b)

Clean terminal (there may still be some other errors that may occur occasionally):
![WhatsApp Image 2025-11-08 at 11 14 55 (2)](https://github.com/user-attachments/assets/c4b3b105-ec58-438e-ab0a-91307f0390b9)
