### PR TITLE
fix: add virtual destructor to ApplicationContext

### DIFF
--- a/src/framework/core/application.h
+++ b/src/framework/core/application.h
@@ -28,6 +28,7 @@ class ApplicationContext
 {
 public:
     ApplicationContext() = default;
+    virtual ~ApplicationContext() = default;
 };
 
 //@bindsingleton g_app


### PR DESCRIPTION
This pull request makes a small change to the `ApplicationContext` class in `src/framework/core/application.h`, ensuring proper cleanup for derived classes by adding a virtual destructor.

Fix for this crash: 

=================================================================
==13160==ERROR: AddressSanitizer: new-delete-type-mismatch on 0x1253229c86f0 in thread T0:
  object passed to delete has wrong type:
  size of the allocated type:   24 bytes;
  size of the deallocated type: 1 bytes.
==13160==WARNING: Failed to use and restart external symbolizer!
    #0 0x7ff645b10bd3 in operator delete D:\a\_work\1\s\src\vctools\asan\llvm\compiler-rt\lib\asan\asan_win_delete_scalar_size_thunk.cpp:41
    #1 0x7ff644a7a356 in std::default_delete<ApplicationContext>::operator() C:\Program Files\Microsoft Visual Studio\18\Insiders\VC\Tools\MSVC\14.50.35717\include\memory:3338
    #2 0x7ff644a6e293 in std::unique_ptr<ApplicationContext,std::default_delete<ApplicationContext> >::~unique_ptr<ApplicationContext,std::default_delete<ApplicationContext> > C:\Program Files\Microsoft Visual Studio\18\Insiders\VC\Tools\MSVC\14.50.35717\include\memory:3456
    #3 0x7ff644a621bb in Application::~Application D:\OpenTibia\GitHub\asteria-client-new\src\framework\core\application.h:37
    #4 0x7ff644a62195 in GraphicalApplication::~GraphicalApplication+0x25 (D:\OpenTibia\GitHub\asteria-client-new\otclient.exe+0x140442195)
    #5 0x7ff6461757cf in `dynamic atexit destructor for 'g_app''+0xf (D:\OpenTibia\GitHub\asteria-client-new\otclient.exe+0x141b557cf)
    #6 0x7ffe23632b98 in initterm_e+0x688 (C:\WINDOWS\SYSTEM32\ucrtbased.dll+0x1800a2b98)
    #7 0x7ffe236325c4 in initterm_e+0xb4 (C:\WINDOWS\SYSTEM32\ucrtbased.dll+0x1800a25c4)
    #8 0x7ffe23632716 in initterm_e+0x206 (C:\WINDOWS\SYSTEM32\ucrtbased.dll+0x1800a2716)
    #9 0x7ffe23632d43 in execute_onexit_table+0x33 (C:\WINDOWS\SYSTEM32\ucrtbased.dll+0x1800a2d43)
    #10 0x7ffe23631f79 in wassert+0x329 (C:\WINDOWS\SYSTEM32\ucrtbased.dll+0x1800a1f79)
    #11 0x7ffe23631e0c in wassert+0x1bc (C:\WINDOWS\SYSTEM32\ucrtbased.dll+0x1800a1e0c)
    #12 0x7ffe23631e86 in wassert+0x236 (C:\WINDOWS\SYSTEM32\ucrtbased.dll+0x1800a1e86)
    #13 0x7ffe2363211f in wassert+0x4cf (C:\WINDOWS\SYSTEM32\ucrtbased.dll+0x1800a211f)
    #14 0x7ffe23632455 in exit+0x15 (C:\WINDOWS\SYSTEM32\ucrtbased.dll+0x1800a2455)
    #15 0x7ff645b1266a in __scrt_common_main_seh D:\a\_work\1\s\src\vctools\crt\vcstartup\src\startup\exe_common.inl:295
    #16 0x7ff645b1250d in __scrt_common_main D:\a\_work\1\s\src\vctools\crt\vcstartup\src\startup\exe_common.inl:330
    #17 0x7ff645b1277d in mainCRTStartup D:\a\_work\1\s\src\vctools\crt\vcstartup\src\startup\exe_main.cpp:16
    #18 0x7fff39f2e8d6 in BaseThreadInitThunk+0x16 (C:\WINDOWS\System32\KERNEL32.DLL+0x18002e8d6)
    #19 0x7fff3bf8c53b in RtlUserThreadStart+0x2b (C:\WINDOWS\SYSTEM32\ntdll.dll+0x18008c53b)

0x1253229c86f0 is located 0 bytes inside of 24-byte region [0x1253229c86f0,0x1253229c8708)
allocated by thread T0 here:
    #0 0x7ff645b10ac5 in operator new D:\a\_work\1\s\src\vctools\asan\llvm\compiler-rt\lib\asan\asan_win_new_scalar_thunk.cpp:40
    #1 0x7ff645c7c81b in main D:\OpenTibia\GitHub\asteria-client-new\src\main.cpp:83
    #2 0x7ff645b12708 in invoke_main D:\a\_work\1\s\src\vctools\crt\vcstartup\src\startup\exe_common.inl:78
    #3 0x7ff645b12651 in __scrt_common_main_seh D:\a\_work\1\s\src\vctools\crt\vcstartup\src\startup\exe_common.inl:288
    #4 0x7ff645b1250d in __scrt_common_main D:\a\_work\1\s\src\vctools\crt\vcstartup\src\startup\exe_common.inl:330
    #5 0x7ff645b1277d in mainCRTStartup D:\a\_work\1\s\src\vctools\crt\vcstartup\src\startup\exe_main.cpp:16
    #6 0x7fff39f2e8d6 in BaseThreadInitThunk+0x16 (C:\WINDOWS\System32\KERNEL32.DLL+0x18002e8d6)
    #7 0x7fff3bf8c53b in RtlUserThreadStart+0x2b (C:\WINDOWS\SYSTEM32\ntdll.dll+0x18008c53b)

SUMMARY: AddressSanitizer: new-delete-type-mismatch C:\Program Files\Microsoft Visual Studio\18\Insiders\VC\Tools\MSVC\14.50.35717\include\memory:3338 in std::default_delete<ApplicationContext>::operator()
==13160==HINT: if you don't care about these errors you may set ASAN_OPTIONS=new_delete_type_mismatch=0
==13160==ABORTING