### PR TITLE
feature: support large spritesheets

### DIFF
--- a/src/client/spriteappearances.cpp
+++ b/src/client/spriteappearances.cpp
@@ -48,18 +48,56 @@ void SpriteAppearances::terminate()
 }
 
 Size SpriteSheet::getSpriteSize() const
-{
-    Size size(g_gameConfig.getSpriteSize(), g_gameConfig.getSpriteSize());
+{    
+    // this array includes all possible combinations within 384x384 sheet
+    // if you intend to change that, you will also have to modify the assets editor
+    // CHANGING THIS MAY BREAK READING EXISTING SPRITESHEETS
 
-    switch (spriteLayout) {
-        case SpriteLayout::ONE_BY_ONE: break;
-        case SpriteLayout::ONE_BY_TWO: size.setHeight(64); break;
-        case SpriteLayout::TWO_BY_ONE: size.setWidth(64); break;
-        case SpriteLayout::TWO_BY_TWO: size.resize(64, 64); break;
-        default: break;
-    }
+    // tile sizes in spritesheets, see SpriteLayout for array key definitions
+    static const std::array<Size, 36> sizes = {
+        Size(32,32),  // 0
+        Size(32,64),  // 1
+        Size(64,32),  // 2
+        Size(64,64),  // 3
+        Size(32,96),  // 4
+        Size(32,128), // 5
+        Size(32,192), // 6
+        Size(32,384), // 7
+        Size(64,96),  // 8
+        Size(64,128), // 9
+        Size(64,192), // 10
+        Size(64,384), // 11
+        Size(96,32),  // 12
+        Size(96,64),  // 13
+        Size(96,96),  // 14
+        Size(96,128), // 15
+        Size(96,192), // 16
+        Size(96,384), // 17
+        Size(128,32),  // 18
+        Size(128,64),  // 19
+        Size(128,96),  // 20
+        Size(128,128), // 21
+        Size(128,192), // 22
+        Size(128,384), // 23
+        Size(192,32),  // 24
+        Size(192,64),  // 25
+        Size(192,96),  // 26
+        Size(192,128), // 27
+        Size(192,192), // 28
+        Size(192,384), // 29
+        Size(384,32),  // 30
+        Size(384,64),  // 31
+        Size(384,96),  // 32
+        Size(384,128), // 33
+        Size(384,192), // 34
+        Size(384,384)  // 35
+    };
 
-    return size;
+    const size_t idx = static_cast<size_t>(spriteLayout);
+    if (idx < sizes.size())
+        return sizes[idx];
+
+    return sizes[0];
 }
 
 bool SpriteAppearances::loadSpriteSheet(const SpriteSheetPtr& sheet) const

--- a/src/client/spriteappearances.h
+++ b/src/client/spriteappearances.h
@@ -27,10 +27,45 @@
 
 enum class SpriteLayout
 {
-    ONE_BY_ONE = 0,
-    ONE_BY_TWO = 1,
-    TWO_BY_ONE = 2,
-    TWO_BY_TWO = 3
+    // default sheet sizes
+    SIZE_32_32 = 0,
+    SIZE_32_64 = 1,
+    SIZE_64_32 = 2,
+    SIZE_64_64 = 3,
+
+    // extended sheet sizes (all possible combinations within 384x384 spritesheet)
+    SIZE_32_96  = 4,
+    SIZE_32_128 = 5,
+    SIZE_32_192 = 6,
+    SIZE_32_384 = 7,
+    SIZE_64_96  = 8,
+    SIZE_64_128 = 9,
+    SIZE_64_192 = 10,
+    SIZE_64_384 = 11,
+    SIZE_96_32  = 12,
+    SIZE_96_64  = 13,
+    SIZE_96_96  = 14,
+    SIZE_96_128 = 15,
+    SIZE_96_192 = 16,
+    SIZE_96_384 = 17,
+    SIZE_128_32  = 18,
+    SIZE_128_64  = 19,
+    SIZE_128_96  = 20,
+    SIZE_128_128 = 21,
+    SIZE_128_192 = 22,
+    SIZE_128_384 = 23,
+    SIZE_192_32  = 24,
+    SIZE_192_64  = 25,
+    SIZE_192_96  = 26,
+    SIZE_192_128 = 27,
+    SIZE_192_192 = 28,
+    SIZE_192_384 = 29,
+    SIZE_384_32  = 30,
+    SIZE_384_64  = 31,
+    SIZE_384_96  = 32,
+    SIZE_384_128 = 33,
+    SIZE_384_192 = 34,
+    SIZE_384_384 = 35
 };
 
 enum class SpriteLoadState
@@ -58,7 +93,7 @@ public:
     int firstId = 0;
     int lastId = 0;
 
-    SpriteLayout spriteLayout = SpriteLayout::ONE_BY_ONE;
+    SpriteLayout spriteLayout = SpriteLayout::SIZE_32_32;
     std::atomic<SpriteLoadState> m_loadingState = SpriteLoadState::NONE;
     std::unique_ptr<uint8_t[]> data;
     std::string file;

--- a/vc17/otclient.vcxproj
+++ b/vc17/otclient.vcxproj
@@ -170,8 +170,8 @@
       <Optimization>Disabled</Optimization>
       <EnableEnhancedInstructionSet>StreamingSIMDExtensions2</EnableEnhancedInstructionSet>
       <AdditionalIncludeDirectories>
-        $(VcpkgRoot)\installed\$(VcpkgTriplet)\include\luajit;
-        $(GITHUB_WORKSPACE)\vcpkg\installed\$(VcpkgTriplet)\include\;
+        $(VcpkgInstalledDir)\include\luajit;
+		$(VcpkgInstalledDir)\include\;
         generated;
         %(AdditionalIncludeDirectories)
       </AdditionalIncludeDirectories>
@@ -195,8 +195,8 @@
       <Optimization>Disabled</Optimization>
       <EnableEnhancedInstructionSet>AdvancedVectorExtensions</EnableEnhancedInstructionSet>
       <AdditionalIncludeDirectories>
-        $(VcpkgRoot)\installed\$(VcpkgTriplet)\include\luajit;
-        $(GITHUB_WORKSPACE)\vcpkg\installed\$(VcpkgTriplet)\include\;
+        $(VcpkgInstalledDir)\include\luajit;
+        $(VcpkgInstalledDir)\include\;
         generated;
         %(AdditionalIncludeDirectories)
       </AdditionalIncludeDirectories>
@@ -220,8 +220,8 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <EnableFiberSafeOptimizations>true</EnableFiberSafeOptimizations>
       <AdditionalIncludeDirectories>
-        $(VcpkgRoot)\installed\$(VcpkgTriplet)\include\luajit;
-        $(GITHUB_WORKSPACE)\vcpkg\installed\$(VcpkgTriplet)\include\;
+        $(VcpkgInstalledDir)\include\luajit;
+        $(VcpkgInstalledDir)\include\;
         generated;
         %(AdditionalIncludeDirectories)
       </AdditionalIncludeDirectories>
@@ -250,8 +250,8 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <EnableFiberSafeOptimizations>true</EnableFiberSafeOptimizations>
       <AdditionalIncludeDirectories>
-        $(VcpkgRoot)\installed\$(VcpkgTriplet)\include\luajit;
-        $(GITHUB_WORKSPACE)\vcpkg\installed\$(VcpkgTriplet)\include\;
+        $(VcpkgInstalledDir)\include\luajit;
+        $(VcpkgInstalledDir)\include\;
         generated;
         %(AdditionalIncludeDirectories)
       </AdditionalIncludeDirectories>
@@ -281,8 +281,8 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <EnableFiberSafeOptimizations>true</EnableFiberSafeOptimizations>
       <AdditionalIncludeDirectories>
-        $(VcpkgRoot)\installed\$(VcpkgTriplet)\include\luajit;
-        $(GITHUB_WORKSPACE)\vcpkg\installed\$(VcpkgTriplet)\include\;
+        $(VcpkgInstalledDir)\include\luajit;
+        $(VcpkgInstalledDir)\include\;
         generated;
         %(AdditionalIncludeDirectories)
       </AdditionalIncludeDirectories>
@@ -310,8 +310,8 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <EnableFiberSafeOptimizations>true</EnableFiberSafeOptimizations>
       <AdditionalIncludeDirectories>
-        $(VcpkgRoot)\installed\$(VcpkgTriplet)\include\luajit;
-        $(GITHUB_WORKSPACE)\vcpkg\installed\$(VcpkgTriplet)\include\;
+        $(VcpkgInstalledDir)\include\luajit;
+        $(VcpkgInstalledDir)\include\;
         generated;
         %(AdditionalIncludeDirectories)
       </AdditionalIncludeDirectories>
@@ -711,12 +711,12 @@
     <Message Text="RunProtoCompile value: $(RunProtoCompile)" Importance="high" />
   </Target>
   <PropertyGroup Condition="'$(RunProtoCompile)'=='true'">
-    <ProtocPath>$(ProjectDir)vcpkg_installed\$(VcpkgTriplet)\tools\protobuf\protoc</ProtocPath>
+    <ProtocPath>$(VcpkgInstalledDir)\$(VcpkgTriplet)\tools\protobuf\protoc.exe</ProtocPath>
     <ProtoPath>$(SourcePath)protobuf</ProtoPath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(RunProtoCompile)'=='false'">
-    <ProtocPath>$(ProjectDir)vcpkg_installed\$(VcpkgTriplet)\tools\protobuf\protoc</ProtocPath>
-    <ProtoPath>$(GITHUB_WORKSPACE)\src\protobuf</ProtoPath>
+    <ProtocPath>$(VcpkgInstalledDir)\$(VcpkgTriplet)\tools\protobuf\protoc.exe</ProtocPath>
+    <ProtoPath>$(SourcePath)protobuf</ProtoPath>
   </PropertyGroup>
   <ItemGroup>
     <ProtoFiles Include="$(ProtoPath)\*.proto" />
@@ -735,7 +735,4 @@
     </ItemGroup>
   </Target>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
-  <ImportGroup Label="ExtensionTargets">
-    <Import Project="$(VcpkgRoot)\scripts\buildsystems\msbuild\vcpkg.targets" Condition="Exists('$(VcpkgRoot)\scripts\buildsystems\msbuild\vcpkg.targets')" />
-  </ImportGroup>
 </Project>


### PR DESCRIPTION
# Description

Preparation for upcoming assets editor feature:
<img width="287" height="365" alt="obraz" src="https://github.com/user-attachments/assets/2dab5838-c702-4a13-a4f7-71e7f316ad48" />

Supports images up to 384x384 (12x12 tiles)

https://github.com/user-attachments/assets/c1f4f4b6-a281-41aa-a354-6eb84f8f15bf


Tested in game, works really well

## Type of change

  - [ ] Bug fix (non-breaking change which fixes an issue)
  - [x] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [ ] This change requires a documentation update

## How Has This Been Tested

- I modified my assets editor in order to support all possible combinations of spritesheets
- I have built a 96x96 outfit and set it to my character. Walked around in depot and didn't encounter any glitches

## Checklist

  - [ ] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [ ] I checked the PR checks reports
  - [x] I have commented my code, particularly in hard-to-understand areas
  - [ ] I have made corresponding changes to the documentation
  - [x] My changes generate no new warnings
  - [ ] I have added tests that prove my fix is effective or that my feature works
