### PR TITLE
fix: adjust X11 None usage and refactor sound manager to fix linux-debug build

### DIFF
--- a/src/framework/platform/x11window.cpp
+++ b/src/framework/platform/x11window.cpp
@@ -225,9 +225,9 @@ void X11Window::init()
 
 void X11Window::terminate()
 {
-    if (m_cursor != None) {
+    if (m_cursor != X11None) {
         XUndefineCursor(m_display, m_window);
-        m_cursor = None;
+        m_cursor = X11None;
     }
 
     if (m_hiddenCursor) {
@@ -424,7 +424,7 @@ void X11Window::internalChooseGLVisual()
         GLX_GREEN_SIZE, 8,
         GLX_BLUE_SIZE, 8,
         GLX_ALPHA_SIZE, 8,
-        None
+        X11None
     };
 
     int nelements;
@@ -483,7 +483,7 @@ void X11Window::internalDestroyGLContext()
     }
 #else
     if (m_glxContext) {
-        glXMakeCurrent(m_display, None, nullptr);
+        glXMakeCurrent(m_display, X11None, nullptr);
         glXDestroyContext(m_display, m_glxContext);
         m_glxContext = nullptr;
     }
@@ -876,10 +876,10 @@ void X11Window::showMouse()
 void X11Window::hideMouse()
 {
     g_mainDispatcher.addEvent([&] {
-        if (m_cursor != None)
+        if (m_cursor != X11None)
             restoreMouseCursor();
 
-        if (m_hiddenCursor == None) {
+        if (m_hiddenCursor == X11None) {
             char bm[] = { 0, 0, 0, 0, 0, 0, 0, 0 };
             Pixmap pix = XCreateBitmapFromData(m_display, m_window, bm, 8, 8);
             XColor black;
@@ -900,7 +900,7 @@ void X11Window::setMouseCursor(int cursorId)
         if (cursorId >= (int)m_cursors.size() || cursorId < 0)
             return;
 
-        if (m_cursor != None)
+        if (m_cursor != X11None)
             restoreMouseCursor();
 
         m_cursor = m_cursors[cursorId];
@@ -912,7 +912,7 @@ void X11Window::restoreMouseCursor()
 {
     g_mainDispatcher.addEvent([&] {
         XUndefineCursor(m_display, m_window);
-        m_cursor = None;
+        m_cursor = X11None;
         });
 }
 
@@ -1074,7 +1074,7 @@ std::string X11Window::getClipboardText()
         return m_clipboardText;
 
     std::string clipboardText;
-    if (ownerWindow != None) {
+    if (ownerWindow != X11None) {
         XConvertSelection(m_display, clipboard, XA_STRING, XA_PRIMARY, ownerWindow, CurrentTime);
         XFlush(m_display);
 

--- a/src/framework/platform/x11window.h
+++ b/src/framework/platform/x11window.h
@@ -29,6 +29,10 @@
 #include <X11/Xlib.h>
 #include <X11/Xatom.h>
 
+#ifdef None
+#undef None
+#endif
+
 #ifdef OPENGL_ES
 #include <EGL/egl.h>
 #else

--- a/src/framework/platform/x11window.h
+++ b/src/framework/platform/x11window.h
@@ -29,6 +29,8 @@
 #include <X11/Xlib.h>
 #include <X11/Xatom.h>
 
+inline constexpr auto X11None = None;
+
 #ifdef None
 #undef None
 #endif

--- a/src/framework/sound/soundmanager.cpp
+++ b/src/framework/sound/soundmanager.cpp
@@ -30,6 +30,7 @@
 #include "soundfile.h"
 #include "soundsource.h"
 #include "streamsoundsource.h"
+#include "combinedsoundsource.h"
 #include "client/game.h"
 #include "framework/core/asyncdispatcher.h"
 #include "framework/core/clock.h"
@@ -39,11 +40,6 @@
 using namespace otclient::protobuf;
 
 using json = nlohmann::json;
-
-class StreamSoundSource;
-class CombinedSoundSource;
-class SoundFile;
-class SoundBuffer;
 
 SoundManager g_sounds;
 

--- a/src/framework/sound/soundmanager.h
+++ b/src/framework/sound/soundmanager.h
@@ -29,6 +29,11 @@ using DelayedSoundEffects = std::vector<DelayedSoundEffect>;
 using ItemCountSoundEffect = std::pair<uint32_t, uint32_t>;
 using ItemCountSoundEffects = std::vector<ItemCountSoundEffect>;
 
+class StreamSoundSource;
+class CombinedSoundSource;
+class SoundFile;
+class SoundBuffer;
+
 enum ClientSoundType
 {
     NUMERIC_SOUND_TYPE_UNKNOWN = 0,


### PR DESCRIPTION
This pull request mainly improves code clarity and maintainability by replacing the usage of the X11 constant `None` with a new project-specific constant `X11None`, and by adjusting related code to use this new identifier. Additionally, it refactors class declarations in the sound manager module for better organization.

**Platform/X11Window changes:**

* Introduced a new constant `X11None` in `x11window.h` to replace the X11 `None` value, and updated all relevant checks and assignments in `x11window.cpp` to use `X11None` instead of `None`. This avoids potential macro conflicts and improves code readability. [[1]](diffhunk://#diff-676bf894588fb596f4bd166af80f9970a8a86c99aeb67b58cb14e5dc5d80be6bR32-R37) [[2]](diffhunk://#diff-951b7ac629dc06588f734f26e893eca6a20635658e8a8fb921634142e9e26ddcL228-R230) [[3]](diffhunk://#diff-951b7ac629dc06588f734f26e893eca6a20635658e8a8fb921634142e9e26ddcL427-R427) [[4]](diffhunk://#diff-951b7ac629dc06588f734f26e893eca6a20635658e8a8fb921634142e9e26ddcL486-R486) [[5]](diffhunk://#diff-951b7ac629dc06588f734f26e893eca6a20635658e8a8fb921634142e9e26ddcL879-R882) [[6]](diffhunk://#diff-951b7ac629dc06588f734f26e893eca6a20635658e8a8fb921634142e9e26ddcL903-R903) [[7]](diffhunk://#diff-951b7ac629dc06588f734f26e893eca6a20635658e8a8fb921634142e9e26ddcL915-R915) [[8]](diffhunk://#diff-951b7ac629dc06588f734f26e893eca6a20635658e8a8fb921634142e9e26ddcL1077-R1077)

**Sound manager refactoring:**

* Moved forward declarations of `StreamSoundSource`, `CombinedSoundSource`, `SoundFile`, and `SoundBuffer` from `soundmanager.cpp` to `soundmanager.h` for better header organization and consistency. [[1]](diffhunk://#diff-d56f17cb34eea622e0bb1aa31c619fee717582aea3728e9092545f822617f902L43-L47) [[2]](diffhunk://#diff-670d1ec240fbc6987997a653a71d0deba3ac3cbe3e371d4b8eb95a8c65fcb607R32-R36)
* Added the missing include for `combinedsoundsource.h` in `soundmanager.cpp` to ensure proper compilation and linkage.