### PR TITLE
fix(game_hotkeys): stop the caret move when writing inside-texts

### DIFF
--- a/modules/game_hotkeys/hotkeys_manager.lua
+++ b/modules/game_hotkeys/hotkeys_manager.lua
@@ -689,10 +689,10 @@ function updateHotkeyForm(reset, dontUpdateCombo)
             hotkeyText:enable()
             hotkeyText:focus()
             hotKeyTextLabel:enable()
+            hotkeyText:setText(currentHotkeyLabel.value)
             if reset then
                 hotkeyText:setCursorPos(-1)
             end
-            hotkeyText:setText(currentHotkeyLabel.value)
             sendAutomatically:setChecked(currentHotkeyLabel.autoSend)
             sendAutomatically:setEnabled(currentHotkeyLabel.value and #currentHotkeyLabel.value > 0)
             selectObjectButton:enable()
@@ -741,7 +741,7 @@ function onHotkeyTextChange(value)
         currentHotkeyLabel.autoSend = false
     end
     updateHotkeyLabel(currentHotkeyLabel)
-    updateHotkeyForm()
+    updateHotkeyForm(false, true)
 end
 
 function onSendAutomaticallyChange(autoSend)
@@ -756,7 +756,7 @@ function onSendAutomaticallyChange(autoSend)
     end
     currentHotkeyLabel.autoSend = autoSend
     updateHotkeyLabel(currentHotkeyLabel)
-    updateHotkeyForm()
+    updateHotkeyForm(false, true)
 end
 
 function onChangeUseType(useTypeWidget)


### PR DESCRIPTION
# Description

While writing inside texts in hotkey window, I was getting sent to the back for some reason, there were no flags added when text is added. Maybe it's intentional but it would be wild.

## Behavior

### **Actual**

https://github.com/user-attachments/assets/d33c7b74-0eec-43f1-8b36-abddec1b808f

### **Expected**

https://github.com/user-attachments/assets/79840aa2-e3aa-4ab9-a66c-4b9fc4845202

## Fixes

- fix bad textedit behavior

## Type of change

Please delete options that are not relevant.

  - [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested

  - [X] Tested the textedit after applying my changes (examples on videos)

**Test Configuration**:

  - Server Version: newest tfs
  - Client: newest mehah
  - Operating System: w11

## Checklist

  - [X] My code follows the style guidelines of this project
  - [X] I have performed a self-review of my own code
  - [X] I checked the PR checks reports
  - [X] I have commented my code, particularly in hard-to-understand areas
  - [X] I have made corresponding changes to the documentation
  - [X] My changes generate no new warnings
  - [X] I have added tests that prove my fix is effective or that my feature works
