### PR TITLE
fix: disable ASAN in Debug build preset

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -94,7 +94,7 @@
       "cacheVariables": {
         "CMAKE_BUILD_TYPE": "Debug",
         "DEBUG_LOG": "ON",
-        "ASAN_ENABLED": "ON",
+        "ASAN_ENABLED": "OFF",
         "BUILD_STATIC_LIBRARY": "OFF",
         "VCPKG_TARGET_TRIPLET": "x64-windows"
       },


### PR DESCRIPTION
This pull request makes a small configuration change to the build presets. The `ASAN_ENABLED` variable is now set to "OFF" in the `CMakePresets.json` file, disabling AddressSanitizer for debug builds.