### PR TITLE
improve: Lua C++ callback exception handling

### DIFF
--- a/src/framework/luaengine/luainterface.cpp
+++ b/src/framework/luaengine/luainterface.cpp
@@ -661,6 +661,18 @@ int LuaInterface::luaCppFunctionCallback(lua_State*)
         numRets = 0;
         g_lua.pushString(fmt::format("C++ call failed: {}", g_lua.traceback(e.what())));
         g_lua.error();
+    } catch (const std::exception& e) {
+        while (g_lua.stackSize() > 0)
+            g_lua.pop();
+        numRets = 0;
+        g_lua.pushString(fmt::format("C++ std::exception: {}", g_lua.traceback(e.what())));
+        g_lua.error();
+    } catch (...) {
+        while (g_lua.stackSize() > 0)
+            g_lua.pop();
+        numRets = 0;
+        g_lua.pushString(g_lua.traceback("Unknown C++ exception"));
+        g_lua.error();
     }
 
     return numRets;

--- a/src/framework/luaengine/luainterface.cpp
+++ b/src/framework/luaengine/luainterface.cpp
@@ -655,6 +655,7 @@ int LuaInterface::luaCppFunctionCallback(lua_State*)
         --g_lua.m_cppCallbackDepth;
         assert(numRets == g_lua.stackSize());
     } catch (stdext::exception& e) {
+        --g_lua.m_cppCallbackDepth;
         // cleanup stack
         while (g_lua.stackSize() > 0)
             g_lua.pop();
@@ -662,12 +663,14 @@ int LuaInterface::luaCppFunctionCallback(lua_State*)
         g_lua.pushString(fmt::format("C++ call failed: {}", g_lua.traceback(e.what())));
         g_lua.error();
     } catch (const std::exception& e) {
+        --g_lua.m_cppCallbackDepth;
         while (g_lua.stackSize() > 0)
             g_lua.pop();
         numRets = 0;
         g_lua.pushString(fmt::format("C++ std::exception: {}", g_lua.traceback(e.what())));
         g_lua.error();
     } catch (...) {
+        --g_lua.m_cppCallbackDepth;
         while (g_lua.stackSize() > 0)
             g_lua.pop();
         numRets = 0;


### PR DESCRIPTION
This pull request improves the error handling in the `luaCppFunctionCallback` function in `luainterface.cpp` by adding more robust exception catching for C++ exceptions.

Error handling improvements:

* Added a catch block for `std::exception` to ensure the Lua stack is cleaned up and a detailed error message is pushed when a standard C++ exception is thrown.
* Added a generic catch-all block to handle any unknown C++ exceptions, ensuring the Lua stack is cleaned up and a generic error message is pushed.