### PR TITLE
improve: error handling for unhandled opcodes

### DIFF
--- a/src/client/protocolgameparse.cpp
+++ b/src/client/protocolgameparse.cpp
@@ -608,21 +608,46 @@ void ProtocolGame::parseMessage(const InputMessagePtr& msg)
                 case Proto::GameServerStoreCompletePurchase:
                     parseCompleteStorePurchase(msg);
                     break;
-                default:
-                    throw Exception("unhandled opcode {}", opcode);
+                default: {
+                    const auto unreadSize = msg->getUnreadSize();
+                    const auto previewSize = std::min<size_t>(unreadSize, 32);
+                    const auto remainingBytes = msg->peekBytes(previewSize);
+
+                    std::stringstream hexDump;
+                    for (const auto byte : remainingBytes) {
+                        hexDump << fmt::format("{:02X} ", byte);
+                    }
+
+                    g_logger.warning(
+                        "Unhandled opcode 0x{:02X} ({}) with {} unread bytes; previous opcode: 0x{:02X} ({}); next bytes: {}",
+                        opcode, opcode, unreadSize, prevOpcode, prevOpcode, hexDump.str());
+                    msg->setReadPos(msg->getMessageSize());
+                    break;
+                }
             }
             prevOpcode = opcode;
         }
     } catch (const stdext::exception& e) {
+        const auto unread = msg->getUnreadSize();
+        const auto readPos = msg->getReadPos();
+        const auto remainingBytes = msg->peekBytes(unread);
+
+        std::stringstream hexDump;
+        for (const auto byte : remainingBytes) {
+            hexDump << fmt::format("{:02X} ", byte);
+        }
+
         g_logger.error(
-            "ProtocolGame parse message exception ({} bytes, {} unread, last opcode is 0x{:02X} ({}), prev opcode is 0x{:02X} ({})): {}\n"
-            "Packet has been saved to packet.log, you can use it to find what was wrong. (Protocol: {})",
+            "ProtocolGame parse message exception ({} bytes, {} unread at pos {}, last opcode: 0x{:02X} ({:d}), prev opcode: 0x{:02X} ({:d}), protocol: {}): {}\n"
+            "Next unread bytes: {}\n",
             msg->getMessageSize(),
-            msg->getUnreadSize(),
+            unread,
+            readPos,
             opcode, opcode,
             prevOpcode, prevOpcode,
+            g_game.getProtocolVersion(),
             e.what(),
-            g_game.getProtocolVersion()
+            hexDump.str()
         );
 
         std::ofstream packet("packet.log", std::ios::app);
@@ -631,15 +656,13 @@ void ProtocolGame::parseMessage(const InputMessagePtr& msg)
         }
 
         packet << fmt::format(
-            "ProtocolGame parse message exception ({} bytes, {} unread, last opcode is 0x{:02X} ({}), prev opcode is 0x{:02X} ({}), proto: {}): {}\n",
-            msg->getMessageSize(),
-            msg->getUnreadSize(),
-            opcode,
-            opcode,
-            prevOpcode,
-            prevOpcode,
+            "[EXCEPTION] {} unread bytes at pos: {}, protocol: {}, current: 0x{:02X} ({:d}), prev: 0x{:02X} ({:d}), error: {}\nBytes: {}\n",
+            unread, readPos,
             g_game.getProtocolVersion(),
-            e.what()
+            opcode, opcode,
+            prevOpcode, prevOpcode,
+            e.what(),
+            hexDump.str()
         );
     }
 }

--- a/src/framework/net/inputmessage.h
+++ b/src/framework/net/inputmessage.h
@@ -86,6 +86,18 @@ public:
 
     bool eof() { return (m_readPos - m_headerPos) >= m_messageSize; }
 
+    std::vector<uint8_t> peekBytes(int bytes) const
+    {
+        const int available = m_messageSize - (m_readPos - m_headerPos);
+        if (available <= 0)
+            return {};
+
+        bytes = std::min<uint8_t>(bytes, available);
+        std::vector<uint8_t> data(bytes);
+        std::memcpy(data.data(), m_buffer + m_readPos, bytes);
+        return data;
+    }
+
 protected:
     void reset();
     void fillBuffer(const uint8_t* buffer, uint16_t size);


### PR DESCRIPTION
This pull request improves error handling and diagnostics in the `ProtocolGame::parseMessage` function by enhancing the logging for unhandled opcodes and exceptions. The main changes focus on providing more detailed information about unread bytes and the state of the message when an error occurs, which will help with debugging and protocol analysis.

**Enhanced error handling and diagnostics:**

* Improved logging for unhandled opcodes by including a hex dump of the next unread bytes, the number of unread bytes, and the previous opcode, instead of throwing an exception. The message pointer is advanced to the end after logging.
* Enhanced exception logging to include the unread byte count, read position, protocol version, current and previous opcodes, error message, and a hex dump of the unread bytes, both in the logger and in the `packet.log` file. [[1]](diffhunk://#diff-43e560d491cb3e3ebad39b0bf178799af22655af7919acd50db2e4578986c296L611-R650) [[2]](diffhunk://#diff-43e560d491cb3e3ebad39b0bf178799af22655af7919acd50db2e4578986c296L634-R665)