### PR TITLE
improve: add bounds check for sprites loading

### DIFF
--- a/src/client/spriteappearances.cpp
+++ b/src/client/spriteappearances.cpp
@@ -62,6 +62,14 @@ Size SpriteSheet::getSpriteSize() const
     return size;
 }
 
+int SpriteSheet::getSpritesPerSheet() const
+{
+    const Size& size = getSpriteSize();
+    const int spritesPerColumn = SpriteSheet::SIZE / size.height();
+
+    return getColumns() * spritesPerColumn;
+}
+
 bool SpriteAppearances::loadSpriteSheet(const SpriteSheetPtr& sheet) const
 {
     if (sheet->m_loadingState.load(std::memory_order_acquire) == SpriteLoadState::LOADING)
@@ -233,6 +241,12 @@ ImagePtr SpriteAppearances::getSpriteImage(const int id, bool& isLoading)
 
         const int spriteOffset = id - sheet->firstId;
         const int allColumns = sheet->getColumns();
+        const int spritesPerSheet = sheet->getSpritesPerSheet();
+
+        if (spriteOffset < 0 || spriteOffset >= spritesPerSheet) {
+            g_logger.error("Sprite id {} is out of bounds for sheet {} (offset {}, max {})", id, sheet->file, spriteOffset, spritesPerSheet);
+            return nullptr;
+        }
         const int spriteRow = std::floor(static_cast<float>(spriteOffset) / static_cast<float>(allColumns));
         const int spriteColumn = spriteOffset % allColumns;
 

--- a/src/client/spriteappearances.h
+++ b/src/client/spriteappearances.h
@@ -52,6 +52,8 @@ public:
 
     Size getSpriteSize() const;
 
+    int getSpritesPerSheet() const;
+
     // 64 pixel width == 6 columns each 64x or 32 pixels, 12 columns
     int getColumns() const { return SIZE / getSpriteSize().width(); }
 

--- a/src/client/thingtype.cpp
+++ b/src/client/thingtype.cpp
@@ -38,7 +38,7 @@
 const static TexturePtr m_textureNull;
 
 namespace {
-static std::string_view categoryName(const ThingCategory category)
+std::string_view categoryName(const ThingCategory category)
 {
     switch (category) {
         case ThingCategoryItem: return "item";

--- a/src/client/thingtype.cpp
+++ b/src/client/thingtype.cpp
@@ -37,6 +37,19 @@
 
 const static TexturePtr m_textureNull;
 
+namespace {
+static std::string_view categoryName(const ThingCategory category)
+{
+    switch (category) {
+        case ThingCategoryItem: return "item";
+        case ThingCategoryCreature: return "creature";
+        case ThingCategoryEffect: return "effect";
+        case ThingCategoryMissile: return "missile";
+        default: return "unknown";
+    }
+}
+}
+
 void ThingType::unserializeAppearance(const uint16_t clientId, const ThingCategory category, const appearances::Appearance& appearance)
 {
     m_null = false;
@@ -744,21 +757,24 @@ void ThingType::loadTexture(const int animationPhase)
                             if (isLoading)
                                 return;
 
+                            if (!spriteImage) {
+                                g_logger.error("Failed to fetch sprite id {} for thing {} ({}, {}), layer {}, pattern {}x{}x{}, frame {}", spriteId, m_name, m_id, categoryName(m_category), l, x, y, z, animationPhase);
+                                return;
+                            }
+
                             // verifies that the first block in the lower right corner is transparent.
                             if (!spriteImage || spriteImage->hasTransparentPixel()) {
                                 fullImage->setTransparentPixel(true);
                             }
 
-                            if (spriteImage) {
-                                if (spriteMask) {
-                                    spriteImage->overwriteMask(maskColors[(l - 1)]);
-                                }
-
-                                auto spriteSize = spriteImage->getSize() / g_gameConfig.getSpriteSize();
-
-                                const Point& spritePos = Point(m_size.width() - spriteSize.width(), m_size.height() - spriteSize.height()) * g_gameConfig.getSpriteSize();
-                                fullImage->blit(framePos + spritePos, spriteImage);
+                            if (spriteMask) {
+                                spriteImage->overwriteMask(maskColors[(l - 1)]);
                             }
+
+                            auto spriteSize = spriteImage->getSize() / g_gameConfig.getSpriteSize();
+
+                            const Point& spritePos = Point(m_size.width() - spriteSize.width(), m_size.height() - spriteSize.height()) * g_gameConfig.getSpriteSize();
+                            fullImage->blit(framePos + spritePos, spriteImage);
                         } else {
                             for (int h = 0; h < m_size.height(); ++h) {
                                 for (int w = 0; w < m_size.width(); ++w) {
@@ -770,19 +786,22 @@ void ThingType::loadTexture(const int animationPhase)
                                     if (isLoading)
                                         return;
 
+                                    if (!spriteImage) {
+                                        g_logger.error("Failed to fetch sprite id {} for thing {} ({}, {}), layer {}, pattern {}x{}x{}, frame {}, offset {}x{}", spriteId, m_name, m_id, categoryName(m_category), l, x, y, z, framePos, w, h);
+                                        return;
+                                    }
+
                                     // verifies that the first block in the lower right corner is transparent.
                                     if (h == 0 && w == 0 && (!spriteImage || spriteImage->hasTransparentPixel())) {
                                         fullImage->setTransparentPixel(true);
                                     }
 
-                                    if (spriteImage) {
-                                        if (spriteMask) {
-                                            spriteImage->overwriteMask(maskColors[(l - 1)]);
-                                        }
-
-                                        const Point& spritePos = Point(m_size.width() - w - 1, m_size.height() - h - 1) * g_gameConfig.getSpriteSize();
-                                        fullImage->blit(framePos + spritePos, spriteImage);
+                                    if (spriteMask) {
+                                        spriteImage->overwriteMask(maskColors[(l - 1)]);
                                     }
+
+                                    const Point& spritePos = Point(m_size.width() - w - 1, m_size.height() - h - 1) * g_gameConfig.getSpriteSize();
+                                    fullImage->blit(framePos + spritePos, spriteImage);
                                 }
                             }
                         }

--- a/src/client/thingtypemanager.cpp
+++ b/src/client/thingtypemanager.cpp
@@ -156,7 +156,15 @@ bool ThingTypeManager::loadAppearances(const std::string& file)
                     appearancesFile = obj["file"];
                 } else if (type == "sprite") {
                     int lastSpriteId = obj["lastspriteid"].get<int>();
-                    g_spriteAppearances.addSpriteSheet(std::make_shared<SpriteSheet>(obj["firstspriteid"].get<int>(), lastSpriteId, static_cast<SpriteLayout>(obj["spritetype"].get<int>()), obj["file"].get<std::string>()));
+                    const auto& sheet = std::make_shared<SpriteSheet>(obj["firstspriteid"].get<int>(), lastSpriteId, static_cast<SpriteLayout>(obj["spritetype"].get<int>()), obj["file"].get<std::string>());
+                    const int spritesPerSheet = sheet->getSpritesPerSheet();
+                    const int maxSpriteId = sheet->firstId + spritesPerSheet - 1;
+                    if (lastSpriteId > maxSpriteId) {
+                        g_logger.debug("Sprite sheet '{}' lastspriteid {} exceeds capacity {}, clamping to {}", sheet->file, lastSpriteId, maxSpriteId, maxSpriteId);
+                        lastSpriteId = maxSpriteId;
+                        sheet->lastId = maxSpriteId;
+                    }
+                    g_spriteAppearances.addSpriteSheet(sheet);
                     spritesCount = std::max<int>(spritesCount, lastSpriteId);
                 }
             }

--- a/src/client/thingtypemanager.h
+++ b/src/client/thingtypemanager.h
@@ -76,7 +76,7 @@ public:
     uint16_t getContentRevision() { return m_contentRevision; }
 
     bool isDatLoaded() { return m_datLoaded; }
-    bool isValidDatId(const uint16_t id, const ThingCategory category) const { return id >= 1 && id < m_thingTypes[category].size(); }
+    bool isValidDatId(const uint16_t id, const ThingCategory category) const { return category < ThingLastCategory && id >= 1 && id < m_thingTypes[category].size(); }
 
 private:
     ThingTypeList m_thingTypes[ThingLastCategory];

--- a/src/framework/util/point.h
+++ b/src/framework/util/point.h
@@ -94,5 +94,17 @@ public:
     }
 };
 
+template <class T>
+struct fmt::formatter<TPoint<T>, char> {
+    constexpr auto parse(format_parse_context& ctx)
+        -> decltype(ctx.begin()) { return ctx.begin(); }
+
+    template <typename FormatContext>
+    auto format(const TPoint<T>& p, FormatContext& ctx) const
+        -> decltype(ctx.out()) {
+        return fmt::format_to(ctx.out(), "{} {}", p.x, p.y);
+    }
+};
+
 using Point = TPoint<int>;
 using PointF = TPoint<float>;

--- a/src/framework/util/point.h
+++ b/src/framework/util/point.h
@@ -96,7 +96,7 @@ public:
 
 template <class T>
 struct fmt::formatter<TPoint<T>, char> {
-    constexpr auto parse(format_parse_context& ctx)
+    constexpr auto parse(format_parse_context& ctx) const
         -> decltype(ctx.begin()) { return ctx.begin(); }
 
     template <typename FormatContext>


### PR DESCRIPTION
This pull request introduces several improvements and bug fixes related to sprite sheet management, error handling, and outfit assignment in the client codebase. The changes enhance robustness by adding bounds checking, improving error reporting, and ensuring proper handling of invalid data.

### Sprite Sheet Management and Validation
* Added the `getSpritesPerSheet()` method to `SpriteSheet`, and used it to clamp `lastSpriteId` if it exceeds the sheet's capacity when loading appearances, preventing out-of-bounds sprite access. [[1]](diffhunk://#diff-55f7c5d05b433e1059f97d5a97fd7007371b9aa0cdcbedcdd2bf3f110609e877R65-R72) [[2]](diffhunk://#diff-eaacc45e04b33b1e60d4d347d6d2f96fbbdd38ac2e6fa806005aa7b81d3b7980R55-R56) [[3]](diffhunk://#diff-a591160624ee4b80f8cb9de9d9eed30dd50f532a73c246d567d688dedf990d87L159-R167)
* Added bounds checking in `SpriteAppearances::getSpriteImage()` to log and prevent access to sprites outside the valid range for a sheet.

### Error Reporting and Logging
* Improved logging in `ThingType::loadTexture()` to report failures when fetching sprite images, including detailed context such as sprite ID, thing name, category, and pattern/frame info. [[1]](diffhunk://#diff-7d3052fc5ceeba10fe7064b52a13554d24b54229f6c3d831358bab727167edfeR40-R52) [[2]](diffhunk://#diff-7d3052fc5ceeba10fe7064b52a13554d24b54229f6c3d831358bab727167edfeR760-L752) [[3]](diffhunk://#diff-7d3052fc5ceeba10fe7064b52a13554d24b54229f6c3d831358bab727167edfeR789-L778)

### Outfit Assignment and Validation
* Enhanced `Creature::setOutfit()` to handle invalid outfits by setting the appropriate category and reverting to the old outfit if the thing type is invalid, with error logging. [[1]](diffhunk://#diff-4a044acc58513e673d57447364ce72dfaf72f833945aa3d2281e339b1603b1a1R824-R831) [[2]](diffhunk://#diff-4a044acc58513e673d57447364ce72dfaf72f833945aa3d2281e339b1603b1a1L836-L838)

### Miscellaneous
* Strengthened `isValidDatId()` in `ThingTypeManager` to ensure category bounds are checked before validating IDs.