### PR TITLE
fix: ApplicationDrawEventsPtr construction in init

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -80,7 +80,8 @@ extern "C" {
             g_logger.fatal("Unable to find work directory, the application cannot be initialized.");
 
         // initialize application framework and otclient
-        g_app.init(args, new GraphicalApplicationContext(g_gameConfig.getSpriteSize(), ApplicationDrawEventsPtr(&g_client)));
+        const auto drawEvents = ApplicationDrawEventsPtr(&g_client, [](ApplicationDrawEvents*) {});
+        g_app.init(args, new GraphicalApplicationContext(g_gameConfig.getSpriteSize(), drawEvents));
 
 #ifndef ANDROID
 #if ENABLE_DISCORD_RPC == 1


### PR DESCRIPTION
This pull request makes a small change to how the `ApplicationDrawEventsPtr` is constructed when initializing the application framework in `src/main.cpp`. Instead of passing only `&g_client`, it now also passes an empty lambda as a custom deleter, ensuring proper memory management.

* Updated `ApplicationDrawEventsPtr` construction to include an empty lambda as a custom deleter during application initialization in `src/main.cpp`.

Fix for this crash
```
=================================================================
==75780==ERROR: AddressSanitizer: attempting free on address which was not malloc()-ed: 0x7ff71750d380 in thread T0
==75780==WARNING: Failed to use and restart external symbolizer!
    #0 0x7ff7168c7aa3 in operator delete D:\a\_work\1\s\src\vctools\asan\llvm\compiler-rt\lib\asan\asan_win_delete_scalar_size_thunk.cpp:41
    #1 0x7ff71541b080 in Client::`scalar deleting destructor'+0x30 (D:\OpenTibia\GitHub\otclient-mehah\otclient.exe+0x14003b080)
    #2 0x7ff715419557 in std::_Ref_count<Client>::_Destroy C:\Program Files\Microsoft Visual Studio\18\Insiders\VC\Tools\MSVC\14.50.35717\include\memory:1210
    #3 0x7ff715411513 in std::_Ref_count_base::_Decref C:\Program Files\Microsoft Visual Studio\18\Insiders\VC\Tools\MSVC\14.50.35717\include\memory:1183
    #4 0x7ff715419cfa in std::_Ptr_base<ApplicationDrawEvents>::_Decref C:\Program Files\Microsoft Visual Studio\18\Insiders\VC\Tools\MSVC\14.50.35717\include\memory:1408
    #5 0x7ff715415642 in std::shared_ptr<ApplicationDrawEvents>::~shared_ptr<ApplicationDrawEvents> C:\Program Files\Microsoft Visual Studio\18\Insiders\VC\Tools\MSVC\14.50.35717\include\memory:1713
    #6 0x7ff715413b69 in GraphicalApplicationContext::~GraphicalApplicationContext+0x19 (D:\OpenTibia\GitHub\otclient-mehah\otclient.exe+0x140033b69)
    #7 0x7ff715413b26 in GraphicalApplicationContext::`scalar deleting destructor'+0x16 (D:\OpenTibia\GitHub\otclient-mehah\otclient.exe+0x140033b26)
    #8 0x7ff7161ff656 in std::default_delete<ApplicationContext>::operator() C:\Program Files\Microsoft Visual Studio\18\Insiders\VC\Tools\MSVC\14.50.35717\include\memory:3338
    #9 0x7ff7161f58f3 in std::unique_ptr<ApplicationContext,std::default_delete<ApplicationContext> >::~unique_ptr<ApplicationContext,std::default_delete<ApplicationContext> > C:\Program Files\Microsoft Visual Studio\18\Insiders\VC\Tools\MSVC\14.50.35717\include\memory:3456
    #10 0x7ff7161f010b in Application::~Application D:\OpenTibia\GitHub\otclient-mehah\src\framework\core\application.h:38
    #11 0x7ff7161f00e5 in GraphicalApplication::~GraphicalApplication+0x25 (D:\OpenTibia\GitHub\otclient-mehah\otclient.exe+0x140e100e5)
    #12 0x7ff716f2e29f in `dynamic atexit destructor for 'g_app''+0xf (D:\OpenTibia\GitHub\otclient-mehah\otclient.exe+0x141b4e29f)
    #13 0x7ffa7df72b98 in initterm_e+0x688 (C:\WINDOWS\SYSTEM32\ucrtbased.dll+0x1800a2b98)
    #14 0x7ffa7df725c4 in initterm_e+0xb4 (C:\WINDOWS\SYSTEM32\ucrtbased.dll+0x1800a25c4)
    #15 0x7ffa7df72716 in initterm_e+0x206 (C:\WINDOWS\SYSTEM32\ucrtbased.dll+0x1800a2716)
    #16 0x7ffa7df72d43 in execute_onexit_table+0x33 (C:\WINDOWS\SYSTEM32\ucrtbased.dll+0x1800a2d43)
    #17 0x7ffa7df71f79 in wassert+0x329 (C:\WINDOWS\SYSTEM32\ucrtbased.dll+0x1800a1f79)
    #18 0x7ffa7df71e0c in wassert+0x1bc (C:\WINDOWS\SYSTEM32\ucrtbased.dll+0x1800a1e0c)
    #19 0x7ffa7df71e86 in wassert+0x236 (C:\WINDOWS\SYSTEM32\ucrtbased.dll+0x1800a1e86)
    #20 0x7ffa7df7211f in wassert+0x4cf (C:\WINDOWS\SYSTEM32\ucrtbased.dll+0x1800a211f)
    #21 0x7ffa7df72455 in exit+0x15 (C:\WINDOWS\SYSTEM32\ucrtbased.dll+0x1800a2455)
    #22 0x7ff7168c8dfa in __scrt_common_main_seh D:\a\_work\1\s\src\vctools\crt\vcstartup\src\startup\exe_common.inl:295
    #23 0x7ff7168c8c9d in __scrt_common_main D:\a\_work\1\s\src\vctools\crt\vcstartup\src\startup\exe_common.inl:330
    #24 0x7ff7168c8f0d in mainCRTStartup D:\a\_work\1\s\src\vctools\crt\vcstartup\src\startup\exe_main.cpp:16
    #25 0x7ffaef87e8d6 in BaseThreadInitThunk+0x16 (C:\WINDOWS\System32\KERNEL32.DLL+0x18002e8d6)
    #26 0x7ffaf0cec53b in RtlUserThreadStart+0x2b (C:\WINDOWS\SYSTEM32\ntdll.dll+0x18008c53b)

0x7ff71750d380 is located 0 bytes inside of global variable 'g_client' defined in 'client.cpp:42:7' (0x7ff71750d380) of size 32
SUMMARY: AddressSanitizer: bad-free (D:\OpenTibia\GitHub\otclient-mehah\otclient.exe+0x14003b080) in Client::`scalar deleting destructor'+0x30
```