### PR TITLE
fix: icon setting for destroyed UIWidget instances

### DIFF
--- a/src/framework/ui/uiwidgetbasestyle.cpp
+++ b/src/framework/ui/uiwidgetbasestyle.cpp
@@ -804,12 +804,16 @@ void UIWidget::drawIcon(const Rect& screenCoords) const
 
 void UIWidget::setIcon(const std::string& iconFile)
 {
-    g_dispatcher.addEvent([&, iconFile = iconFile] {
-        m_icon = iconFile.empty() ? nullptr : g_textures.getTexture(iconFile);
-        if (m_icon && !m_iconClipRect.isValid()) {
-            m_iconClipRect = Rect(0, 0, m_icon->getSize());
+     const auto self = static_self_cast<UIWidget>();
+    g_dispatcher.addEvent([self, iconFile = iconFile] {
+        if (self->isDestroyed())
+            return;
+
+        self->m_icon = iconFile.empty() ? nullptr : g_textures.getTexture(iconFile);
+        if (self->m_icon && !self->m_iconClipRect.isValid()) {
+            self->m_iconClipRect = Rect(0, 0, self->m_icon->getSize());
         }
 
-        repaint();
+        self->repaint();
     });
 }


### PR DESCRIPTION
This pull request improves the safety and reliability of the `UIWidget::setIcon` method by ensuring that asynchronous icon updates do not occur on destroyed widgets. The main change is the addition of a destruction check before updating the icon and repainting, which helps prevent potential crashes or undefined behavior.

**Widget lifecycle safety:**

* Updated `UIWidget::setIcon` in `src/framework/ui/uiwidgetbasestyle.cpp` to use a local `self` pointer and added a check for `isDestroyed()` before proceeding with icon updates and repainting in the dispatched event. This prevents actions on widgets that have been destroyed.

Fix for this crash:
```
KernelBase.dll!00007ffaee3980da()	Desconhecido
 	[Código Externo]	
 	otclient.exe!std::swap<Texture *,0>(Texture * & _Left, Texture * & _Right) Linha 140	C++
 	otclient.exe!std::_Ptr_base<Texture>::_Swap(std::_Ptr_base<Texture> & _Right) Linha 1414	C++
 	otclient.exe!std::shared_ptr<Texture>::swap(std::shared_ptr<Texture> & _Other) Linha 1756	C++
 	otclient.exe!std::shared_ptr<Texture>::operator=(std::shared_ptr<Texture> && _Right) Linha 1728	C++
 	otclient.exe!UIWidget::setIcon::__l2::<lambda_1>::operator()() Linha 808	C++
 	[Código Externo]	
 	otclient.exe!Event::execute() Linha 37	C++
 	otclient.exe!EventDispatcher::executeEvents() Linha 117	C++
 	otclient.exe!EventDispatcher::poll() Linha 56	C++
 	otclient.exe!Application::poll() Linha 179	C++
>	otclient.exe!GraphicalApplication::poll() Linha 257	C++
 	otclient.exe!GraphicalApplication::run::__l2::<lambda_2>::operator()() Linha 187	C++
 	otclient.exe!BS::thread_pool::submit_task::__l2::<lambda_1>::operator()() Linha 617	C++
 	[Código Externo]	
 	otclient.exe!BS::thread_pool::worker(const unsigned int idx, const std::function<void __cdecl(void)> & init_task) Linha 937	C++
 	[Código Externo]	

Loaded module 'game_bot' (0.88s)
=================================================================
==19576==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x1273abc69478 at pc 0x7ff7e20e3b48 bp 0x00a5aeefec80 sp 0x00a5aeefec88
READ of size 8 at 0x1273abc69478 thread T1
==19576==WARNING: Failed to use and restart external symbolizer!
    #0 0x7ff7e20e3b47 in std::swap<Texture *,0> C:\Program Files\Microsoft Visual Studio\18\Insiders\VC\Tools\MSVC\14.50.35717\include\utility:140
    #1 0x7ff7e20d6acf in std::_Ptr_base<Texture>::_Swap C:\Program Files\Microsoft Visual Studio\18\Insiders\VC\Tools\MSVC\14.50.35717\include\memory:1413
    #2 0x7ff7e20bf00c in std::shared_ptr<Texture>::swap C:\Program Files\Microsoft Visual Studio\18\Insiders\VC\Tools\MSVC\14.50.35717\include\memory:1756
    #3 0x7ff7e209c7fe in std::shared_ptr<Texture>::operator= C:\Program Files\Microsoft Visual Studio\18\Insiders\VC\Tools\MSVC\14.50.35717\include\memory:1728
    #4 0x7ff7e3a13b7b in `UIWidget::setIcon'::`2'::<lambda_1>::operator() D:\OpenTibia\GitHub\otclient-mehah\src\framework\ui\uiwidgetbasestyle.cpp:808
    #5 0x7ff7e33632a2 in std::invoke<`UIWidget::setIcon'::`2'::<lambda_1> &> C:\Program Files\Microsoft Visual Studio\18\Insiders\VC\Tools\MSVC\14.50.35717\include\type_traits:1678
    #6 0x7ff7e39ee549 in std::_Func_impl_no_alloc<`UIWidget::setIcon'::`2'::<lambda_1>,void>::_Do_call C:\Program Files\Microsoft Visual Studio\18\Insiders\VC\Tools\MSVC\14.50.35717\include\functional:883
    #7 0x7ff7e26a2cc6 in std::_Func_class<void>::operator() C:\Program Files\Microsoft Visual Studio\18\Insiders\VC\Tools\MSVC\14.50.35717\include\functional:930
    #8 0x7ff7e391ed3b in Event::execute D:\OpenTibia\GitHub\otclient-mehah\src\framework\core\event.cpp:36
    #9 0x7ff7e3133596 in EventDispatcher::executeEvents D:\OpenTibia\GitHub\otclient-mehah\src\framework\core\eventdispatcher.cpp:117
    #10 0x7ff7e392774c in EventDispatcher::poll D:\OpenTibia\GitHub\otclient-mehah\src\framework\core\eventdispatcher.cpp:55
    #11 0x7ff7e3923775 in Application::poll D:\OpenTibia\GitHub\otclient-mehah\src\framework\core\application.cpp:172
    #12 0x7ff7e37b2507 in GraphicalApplication::poll D:\OpenTibia\GitHub\otclient-mehah\src\framework\core\graphicalapplication.cpp:254
    #13 0x7ff7e37b2e14 in `GraphicalApplication::run'::`2'::<lambda_2>::operator() D:\OpenTibia\GitHub\otclient-mehah\src\framework\core\graphicalapplication.cpp:187
    #14 0x7ff7e37b0cda in `BS::thread_pool::submit_task<`GraphicalApplication::run'::`2'::<lambda_2>,void>'::`2'::<lambda_1>::operator() D:\OpenTibia\GitHub\otclient-mehah\build\windows-debug\vcpkg_installed\x64-windows\include\BS_thread_pool.hpp:617
    #15 0x7ff7e2e56242 in std::invoke<`BS::thread_pool::submit_task<`GraphicalApplication::run'::`2'::<lambda_2>,void>'::`2'::<lambda_1> &> C:\Program Files\Microsoft Visual Studio\18\Insiders\VC\Tools\MSVC\14.50.35717\include\type_traits:1678
    #16 0x7ff7e37ae8a9 in std::_Func_impl_no_alloc<`BS::thread_pool::submit_task<`GraphicalApplication::run'::`2'::<lambda_2>,void>'::`2'::<lambda_1>,void>::_Do_call C:\Program Files\Microsoft Visual Studio\18\Insiders\VC\Tools\MSVC\14.50.35717\include\functional:883
    #17 0x7ff7e26a2cc6 in std::_Func_class<void>::operator() C:\Program Files\Microsoft Visual Studio\18\Insiders\VC\Tools\MSVC\14.50.35717\include\functional:930
    #18 0x7ff7e313292b in BS::thread_pool::worker D:\OpenTibia\GitHub\otclient-mehah\build\windows-debug\vcpkg_installed\x64-windows\include\BS_thread_pool.hpp:937
    #19 0x7ff7e31587c8 in std::invoke<void (__cdecl BS::thread_pool::*)(unsigned int,std::function<void __cdecl(void)> const &),BS::thread_pool *,unsigned int,std::function<void __cdecl(void)> > C:\Program Files\Microsoft Visual Studio\18\Insiders\VC\Tools\MSVC\14.50.35717\include\type_traits:1694
    #20 0x7ff7e3148f49 in std::thread::_Invoke<std::tuple<void (__cdecl BS::thread_pool::*)(unsigned int,std::function<void __cdecl(void)> const &),BS::thread_pool *,unsigned int,std::function<void __cdecl(void)> >,0,1,2,3> C:\Program Files\Microsoft Visual Studio\18\Insiders\VC\Tools\MSVC\14.50.35717\include\thread:60
    #21 0x7ffa808d2ec4 in register_onexit_function+0xf4 (C:\WINDOWS\SYSTEM32\ucrtbased.dll+0x1800a2ec4)
    #22 0x7ffa7ceefeec in _sanitizer_start_switch_fiber+0x270c (C:\Program Files\Microsoft Visual Studio\18\Insiders\VC\Tools\MSVC\14.50.35717\bin\Hostx64\x64\clang_rt.asan_dynamic-x86_64.dll+0x18005feec)
    #23 0x7ffaef87e8d6 in BaseThreadInitThunk+0x16 (C:\WINDOWS\System32\KERNEL32.DLL+0x18002e8d6)
    #24 0x7ffaf0cec53b in RtlUserThreadStart+0x2b (C:\WINDOWS\SYSTEM32\ntdll.dll+0x18008c53b)

Address 0x1273abc69478 is a wild pointer inside of access range of size 0x000000000008.
SUMMARY: AddressSanitizer: heap-buffer-overflow C:\Program Files\Microsoft Visual Studio\18\Insiders\VC\Tools\MSVC\14.50.35717\include\utility:140 in std::swap<Texture *,0>
Shadow bytes around the buggy address:
  0x1273abc69180: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x1273abc69200: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x1273abc69280: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x1273abc69300: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x1273abc69380: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
=>0x1273abc69400: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa[fa]
  0x1273abc69480: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x1273abc69500: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x1273abc69580: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x1273abc69600: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x1273abc69680: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
Thread T1 created by T0 here:
    #0 0x7ffa7cef03a7 in _asan_wrap_CreateThread+0x77 (C:\Program Files\Microsoft Visual Studio\18\Insiders\VC\Tools\MSVC\14.50.35717\bin\Hostx64\x64\clang_rt.asan_dynamic-x86_64.dll+0x1800603a7)
    #1 0x7ffa808d3616 in beginthreadex+0x156 (C:\WINDOWS\SYSTEM32\ucrtbased.dll+0x1800a3616)
    #2 0x7ff7e313e333 in std::thread::_Start<void (__cdecl BS::thread_pool::*)(unsigned int,std::function<void __cdecl(void)> const &),BS::thread_pool *,unsigned int &,std::function<void __cdecl(void)> const &> C:\Program Files\Microsoft Visual Studio\18\Insiders\VC\Tools\MSVC\14.50.35717\include\thread:78
    #3 0x7ff7e31367ea in std::thread::thread<void (__cdecl BS::thread_pool::*)(unsigned int,std::function<void __cdecl(void)> const &),BS::thread_pool *,unsigned int &,std::function<void __cdecl(void)> const &,0> C:\Program Files\Microsoft Visual Studio\18\Insiders\VC\Tools\MSVC\14.50.35717\include\thread:93
    #4 0x7ff7e3131ccc in BS::thread_pool::create_threads D:\OpenTibia\GitHub\otclient-mehah\build\windows-debug\vcpkg_installed\x64-windows\include\BS_thread_pool.hpp:866
    #5 0x7ff7e31311f6 in BS::thread_pool::thread_pool D:\OpenTibia\GitHub\otclient-mehah\build\windows-debug\vcpkg_installed\x64-windows\include\BS_thread_pool.hpp:322
    #6 0x7ff7e3130e69 in BS::thread_pool::thread_pool D:\OpenTibia\GitHub\otclient-mehah\build\windows-debug\vcpkg_installed\x64-windows\include\BS_thread_pool.hpp:305
    #7 0x7ff7e2023c59 in `dynamic initializer for 'g_asyncDispatcher'' D:\OpenTibia\GitHub\otclient-mehah\src\framework\core\asyncdispatcher.cpp:41
    #8 0x7ffa808d24f7 in initterm+0x57 (C:\WINDOWS\SYSTEM32\ucrtbased.dll+0x1800a24f7)
    #9 0x7ff7e3508d3a in __scrt_common_main_seh D:\a\_work\1\s\src\vctools\crt\vcstartup\src\startup\exe_common.inl:256
    #10 0x7ff7e3508c9d in __scrt_common_main D:\a\_work\1\s\src\vctools\crt\vcstartup\src\startup\exe_common.inl:330
    #11 0x7ff7e3508f0d in mainCRTStartup D:\a\_work\1\s\src\vctools\crt\vcstartup\src\startup\exe_main.cpp:16
    #12 0x7ffaef87e8d6 in BaseThreadInitThunk+0x16 (C:\WINDOWS\System32\KERNEL32.DLL+0x18002e8d6)
    #13 0x7ffaf0cec53b in RtlUserThreadStart+0x2b (C:\WINDOWS\SYSTEM32\ntdll.dll+0x18008c53b)
```