### PR TITLE
fix(game_console): WASD toggle for game_hotkeys

### DIFF
--- a/modules/game_console/console.lua
+++ b/modules/game_console/console.lua
@@ -349,6 +349,8 @@ function toggleChat()
     else
         consoleToggleChat:setText(tr('Chat On'))
     end
+    
+    updateChatMode()
 end
 
 -- id of object first and then action
@@ -424,8 +426,6 @@ function switchChatOnCall()
             toggleChat()
         end
     end
-
-    updateChatMode()
 end
 
 function disableChatOnCall()
@@ -436,8 +436,6 @@ function disableChatOnCall()
     if isChatEnabled() and not consoleToggleChat.isChecked then
         toggleChat()
     end
-
-    updateChatMode()
 end
 
 function isChatEnabled()


### PR DESCRIPTION
# Description

WASD toggle from game_hotkeys wasnt toggling chat properly (missing updateChatMode() in toggle function)
i've added it to the toggle function and where updateChatMode() was no longer necessary (toggle was there anyways), removed the usage

## Behavior

### **Actual**


https://github.com/user-attachments/assets/79fdfc92-9630-47ff-81ea-ac26f3d6cf2c



### **Expected**


https://github.com/user-attachments/assets/746308a4-7aea-4eb5-82b6-5404ea145ba7



## Fixes

WASD toggle from game_hotkeys module

## Type of change

  - [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested

  - [X] Video 2.mp4 && tested manually with different toggle types

**Test Configuration**:

  - Server Version: newest tfs
  - Client: newest mehah
  - Operating System: w11

## Checklist

  - [X] My code follows the style guidelines of this project
  - [X] I have performed a self-review of my own code
  - [X] I checked the PR checks reports
  - [X] I have commented my code, particularly in hard-to-understand areas
  - [X] I have made corresponding changes to the documentation
  - [X] My changes generate no new warnings
  - [X] I have added tests that prove my fix is effective or that my feature works
