### PR TITLE
feat: add two-factor authentication support to login

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -9,20 +9,79 @@ Services = {
     --createAccount = "http://localhost/clientcreateaccount.php", --./client_entergame -- createAccount.lua
 }
 
---[[
-Servers_init = {
-    ["http://127.0.0.1/login.php"] = {
-        ["port"] = 80,
-        ["protocol"] = 1320,
-        ["httpLogin"] = true
-    },
-    ["ip.net"] = {
-        ["port"] = 7171,
-        ["protocol"] = 860,
-        ["httpLogin"] = false
-    },
-}
-]]
+--- Enables or disables the entire server configuration block.
+-- Set to `false` to disable all configuration below.
+local ENABLE_SERVERS = true
+
+---
+-- @module Servers_init
+-- Configuration table for all servers used by the system.
+--
+-- This entire block is conditionally enabled based on ENABLE_SERVERS.
+-- When ENABLE_SERVERS == false, everything is ignored/disabled.
+--
+
+---
+-- Server configuration system for multi-server or multi-world clients.
+--
+-- This structure allows a single client build to connect to multiple servers
+-- without requiring duplicate client folders.
+--
+-- A server that hosts several worlds, or that provides a separate test environment,
+-- can simply define additional entries inside this configuration table.
+--
+-- Instead of maintaining multiple client installations (one per world/server),
+-- the client can switch between servers by selecting the desired configuration entry.
+-- This simplifies testing, avoids redundant directories, and centralizes connection settings.
+--
+-- The ENABLE_SERVERS flag allows the entire configuration block to be enabled or disabled
+-- without deleting or commenting out individual entries.
+--
+
+Servers_init = {}
+
+if ENABLE_SERVERS then
+
+    ---
+    -- List of servers and their configuration parameters.
+    -- Each entry defines port, protocol, and authentication options.
+    -- @table Servers_init
+    --
+    Servers_init = {
+
+        -- Local login server
+        ---
+        -- Configuration for local login server.
+        -- @class table
+        -- @name local_login
+        -- @field port Port used for HTTP connection
+        -- @field protocol Protocol identifier used by the application
+        -- @field httpLogin Enables HTTP-based login on the server
+        -- @field useAuthenticator Enables additional authentication layer
+        --
+        ["http://127.0.0.1/login.php"] = {
+            port = 80,
+            protocol = 1412,
+            httpLogin = true,
+            useAuthenticator = true
+        },
+
+        -- External server
+        ---
+        -- Configuration for external server ip.net.
+        -- @class table
+        -- @name ip_net
+        -- @field port TCP port used for connection
+        -- @field protocol Protocol identifier used by the server
+        -- @field httpLogin Indicates if the server allows HTTP login
+        --
+        ["ip.net"] = {
+            port = 7171,
+            protocol = 860,
+            httpLogin = false
+        }
+    }
+end
 
 g_app.setName("OTClient - Redemption");
 g_app.setCompactName("otclient");

--- a/meta.lua
+++ b/meta.lua
@@ -3553,9 +3553,10 @@ function LoginHttp.create() end
 ---@param port integer
 ---@param email string
 ---@param password string
+---@param token string
 ---@param requestId integer
 ---@param httpLogin boolean
-function LoginHttp:httpLogin(host, path, port, email, password, requestId, httpLogin) end
+function LoginHttp:httpLogin(host, path, port, email, password, token, requestId, httpLogin) end
 
 --------------------------------
 ------------ g_http ------------

--- a/modules/client_entergame/authenticatortoken.otui
+++ b/modules/client_entergame/authenticatortoken.otui
@@ -1,0 +1,67 @@
+AuthenticatorTokenWindow < MainWindow
+  id: tokenWindow
+  !text: tr('Two-Factor Authentication')
+  size: 360 130
+  image-source: /images/ui/miniwindow
+  image-border: 10
+  draggable: true
+  moveable: true
+  focusable: true
+  @onEnter: EnterGame.doLoginWithToken()
+  @onEscape: |
+    EnterGame.destroyToken()
+    EnterGame.show()
+
+  Label
+    id: authTokenLabel
+    !text: tr('Please enter your authentication code:')
+    anchors.top: parent.top
+    anchors.left: parent.left
+    anchors.right: parent.right
+    margin-top: 1
+    margin-left: 15
+    margin-right: 15
+    font: verdana-11px-monochrome
+    color: white
+    text-auto-resize: true
+
+  TextEdit
+    id: authenticatorTokenTextEdit
+    anchors.top: prev.bottom
+    anchors.left: parent.left
+    anchors.right: parent.right
+    margin-top: 2
+    margin-left: 15
+    margin-right: 15
+    height: 22
+    font: verdana-11px-monochrome
+    max-length: 8
+    background-color: #1e1e1e
+    border: 1 #000000
+    border-color: #888888
+    text-color: white
+
+  Button
+    id: cancelButton
+    !text: tr('Cancel')
+    width: 60
+    height: 18
+    anchors.top: prev.bottom
+    anchors.left: parent.left
+    margin-top: 2
+    margin-left: 15
+    font: verdana-11px
+    @onClick: |
+      EnterGame.destroyToken()
+      EnterGame.show()
+
+  Button
+    id: confirmButton
+    !text: tr('Ok')
+    width: 60
+    height: 18
+    anchors.top: cancelButton.top
+    anchors.right: parent.right
+    margin-right: 15
+    font: verdana-11px
+    @onClick: EnterGame.doLoginWithToken()

--- a/modules/client_entergame/entergame.otmod
+++ b/modules/client_entergame/entergame.otmod
@@ -9,6 +9,7 @@ Module
     - game_things
 
   @onLoad: |
+    g_ui.importStyle('authenticatortoken.otui')
     dofile 'entergame'
     dofile 'characterlist'
     dofile 'createAccount'

--- a/modules/client_entergame/entergame.otui
+++ b/modules/client_entergame/entergame.otui
@@ -26,11 +26,8 @@ EnterGameWindow
   &authenticatorHeight: 44
   &stayLoggedBoxEnabled: false
   &stayLoggedBoxHeight: 24
-  &disableToken : false
   size: 280 302
   @onEnter: EnterGame.doLogin()
-
-
 
   Label
     id: emailLabel
@@ -49,7 +46,7 @@ EnterGameWindow
     margin-top: 10
     opacity: 0.8
 
-  HiddenTextQtToggleEdit
+  TextEdit
     id: accountNameTextEdit
     anchors.right: accountPasswordTextEdit.right
     anchors.verticalCenter: emailLabel.verticalCenter
@@ -108,32 +105,6 @@ EnterGameWindow
             self:hide()
         end
 
-  MenuLabel
-    id: authenticatorTokenLabel
-    !text: tr('Authenticator Token')
-    anchors.left: prev.left
-    anchors.top: prev.bottom
-    text-auto-resize: true
-    margin-top: -12
-    visible: false
-
-    $on:
-      visible: true
-      margin-top: 8
-
-  TextEdit
-    id: authenticatorTokenTextEdit
-    anchors.left: parent.left
-    anchors.right: parent.right
-    anchors.top: prev.bottom
-    margin-top: -22
-    visible: false
-    max-length: 8
-
-    $on:
-      visible: true
-      margin-top: 2
-
   QtCheckBox
     id: stayLoggedBox
     !text: tr('Stay logged during session')
@@ -168,7 +139,7 @@ EnterGameWindow
     anchors.right: parent.right
     anchors.top: serverLabel.bottom
     margin-top: 3
-    @onClick: ServerList.show()
+    @onClick: EnterGame.showServerList()
 
   TextEdit
     id: serverHostTextEdit
@@ -276,4 +247,3 @@ EnterGameWindow
     margin-top: 5
     color: green
     text-auto-resize: true
-

--- a/modules/client_serverlist/serverlist.lua
+++ b/modules/client_serverlist/serverlist.lua
@@ -1,5 +1,10 @@
 ServerList = {}
 
+function safeDecrypt(text)
+    local success, result = pcall(g_crypt.decrypt, text)
+    return success and result or text
+end
+
 -- private variables
 local serverListWindow = nil
 local serverTextList = nil
@@ -30,7 +35,7 @@ end
 function ServerList.terminate()
     ServerList.destroy()
 
-    g_settings.setNode('ServerList', servers)
+    ServerList.save()
 
     ServerList = nil
     serverListWindow = nil
@@ -49,8 +54,8 @@ function ServerList.select()
         local server = servers[selected:getId()]
         if server then
             EnterGame.setDefaultServer(selected:getId(), server.port, server.protocol)
-            EnterGame.setAccountName(server.account)
-            EnterGame.setPassword(server.password)
+            EnterGame.setAccountName(safeDecrypt(server.account))
+            EnterGame.setPassword(safeDecrypt(server.password))
             EnterGame.setHttpLogin(server.httpLogin)
             ServerList.hide()
         end
@@ -148,13 +153,30 @@ function ServerList.hide()
 end
 
 function ServerList.setServerAccount(host, account)
-    if servers[host] then
-        servers[host].account = account
-    end
+    servers[host] = servers[host] or {}
+    servers[host].account = g_crypt.encrypt(account)
 end
 
 function ServerList.setServerPassword(host, password)
-    if servers[host] then
-        servers[host].password = password
-    end
+    servers[host] = servers[host] or {}
+    servers[host].password = g_crypt.encrypt(password)
+end
+
+function ServerList.setServerAutologin(host, auto)
+    servers[host] = servers[host] or {}
+    servers[host].autologin = auto and true or false
+end
+
+function ServerList.getServerAutologin(host)
+    local servers = g_settings.getNode('ServerList') or {}
+    return servers[host] and servers[host].autologin or false
+end
+
+function ServerList.save()
+    g_settings.setNode('ServerList', servers)
+    g_configs.saveSettings()
+end
+
+function ServerList.getServers()
+    return servers
 end

--- a/src/framework/core/configmanager.cpp
+++ b/src/framework/core/configmanager.cpp
@@ -117,3 +117,9 @@ bool ConfigManager::unload(const std::string& file)
 }
 
 void ConfigManager::remove(const ConfigPtr& config) { m_configs.remove(config); }
+
+void ConfigManager::saveSettings()
+{
+    if (m_settings)
+        m_settings->save();
+}

--- a/src/framework/core/configmanager.h
+++ b/src/framework/core/configmanager.h
@@ -41,6 +41,8 @@ public:
     bool unload(const std::string& file);
     void remove(const ConfigPtr& config);
 
+    void saveSettings();
+
 protected:
     ConfigPtr m_settings;
 

--- a/src/framework/luafunctions.cpp
+++ b/src/framework/luafunctions.cpp
@@ -182,6 +182,7 @@ void Application::registerLuaFunctions()
     g_lua.bindSingletonFunction("g_configs", "load", &ConfigManager::load, &g_configs);
     g_lua.bindSingletonFunction("g_configs", "unload", &ConfigManager::unload, &g_configs);
     g_lua.bindSingletonFunction("g_configs", "create", &ConfigManager::create, &g_configs);
+    g_lua.bindSingletonFunction("g_configs", "saveSettings", &ConfigManager::saveSettings, &g_configs);
 
     // Logger
     g_lua.registerSingletonClass("g_logger");

--- a/src/framework/net/httplogin.cpp
+++ b/src/framework/net/httplogin.cpp
@@ -99,21 +99,19 @@ std::string LoginHttp::getSession() { return this->session; }
 
 void LoginHttp::httpLogin(const std::string& host, const std::string& path,
                           uint16_t port, const std::string& email,
-                          const std::string& password, int request_id,
-                          bool httpLogin) {
+                          const std::string& password, int request_id, bool httpLogin, const std::string& token) {
 #ifndef __EMSCRIPTEN__
+    this->errorMessage.clear();
     g_asyncDispatcher.detach_task(
-        [this, host, path, port, email, password, request_id, httpLogin] {
+        [this, host, path, port, email, password, request_id, token, httpLogin] {
         if (cancelled.load()) return;
         httplib::Result result =
-            this->loginHttpsJson(host, path, port, email, password);
+            this->loginHttpsJson(host, path, port, email, password, token);
         if (httpLogin && (!result || result->status != Success)) {
-            if (cancelled.load()) return;
-            result = loginHttpJson(host, path, port, email, password);
+            result = loginHttpJson(host, path, port, email, password, token);
         }
 
-        if (cancelled.load()) return;
-        if (result && result->status == Success) {
+        if (result && result->status == Success && parseJsonResponse(result->body)) {
             g_dispatcher.addEvent([this, request_id] {
                 if (cancelled.load()) return;
                 g_lua.callGlobalField("EnterGame", "loginSuccess", request_id,
@@ -125,19 +123,38 @@ void LoginHttp::httpLogin(const std::string& host, const std::string& path,
             std::string msg = "";
             if (result) {
                 status = result->status;
+                if (!this->errorMessage.empty()) {
+                    msg = this->errorMessage;
+                }
                 try {
                     const auto body = json::parse(result->body);
-                    if (body.contains("errorMessage")) {
-                        msg = body["errorMessage"];
-                    } else {
-                        msg = "Unexpected JSON format.";
+                    if (msg.empty()) {
+                        msg = body.value("errorMessage", "");
                     }
-                } catch (const std::exception&) {
-                    msg = to_string(result.error());
+                    status = body.value("errorCode", status);
+                } catch (...) {
+                }
+                if (msg.empty()) {
+                    if (status != Success) {
+                        msg = "HTTP " + std::to_string(status);
+                        if (!result->reason.empty()) {
+                            msg += " - " + result->reason;
+                        } else {
+                            msg += " - Unknown status";
+                        }
+                    } else if (!this->errorMessage.empty()) {
+                        msg = this->errorMessage;
+                    } else {
+                        msg = "Invalid response received from server (expected JSON).";
+                    }
                 }
             } else {
                 status = -1;
-                msg = "Unknown error.\nCheck: \n-Enable Http login\n-Check Apache\n-Check login.php\n-check port 80/8080\n-Check Cloudflare";
+                if (this->errorMessage.length() == 0) {
+                    msg = "Failed to connect to login server.";
+                } else {
+                    msg = this->errorMessage;
+                }
             }
 
             g_dispatcher.addEvent([this, request_id, status, msg] {
@@ -148,9 +165,9 @@ void LoginHttp::httpLogin(const std::string& host, const std::string& path,
         }
     });
 #else
+    this->errorMessage.clear();
     g_asyncDispatcher.detach_task(
-        [this, host, path, port, email, password, request_id, httpLogin] {
-        if (cancelled.load()) return;
+        [this, host, path, port, email, password, request_id, token, httpLogin] {
         emscripten_fetch_attr_t attr;
         emscripten_fetch_attr_init(&attr);
         strcpy(attr.requestMethod, "POST");
@@ -160,7 +177,18 @@ void LoginHttp::httpLogin(const std::string& host, const std::string& path,
         };
         attr.requestHeaders = headers;
         attr.attributes = EMSCRIPTEN_FETCH_LOAD_TO_MEMORY | EMSCRIPTEN_FETCH_SYNCHRONOUS;
-        json body = json{ {"email", email}, {"password", password}, {"stayloggedin", true}, {"type", "login"} };
+
+        json body = {
+            {"email", email},
+            {"password", password},
+            {"stayloggedin", true},
+            {"type", "login"}
+        };
+
+        if (!token.empty()) {
+            body["token"] = token;
+        }
+
         std::string bodyStr = body.dump(1);
         attr.requestData = bodyStr.data();
         attr.requestDataSize = bodyStr.length();
@@ -219,7 +247,8 @@ httplib::Result LoginHttp::loginHttpsJson(const std::string& host,
                                           const std::string& path,
                                           const uint16_t port,
                                           const std::string& email,
-                                          const std::string& password) {
+                                          const std::string& password,
+                                          const std::string& token) {
     httplib::SSLClient client(host, port);
 
     client.set_logger(
@@ -229,24 +258,34 @@ httplib::Result LoginHttp::loginHttpsJson(const std::string& host,
     client.enable_server_certificate_verification(false);
     client.enable_server_hostname_verification(false);
 
-    const json body = { {"email", email}, {"password", password}, {"stayloggedin", true}, {"type", "login"} };
+    json body = {
+        {"email", email},
+        {"password", password},
+        {"stayloggedin", true},
+        {"type", "login"}
+    };
+
+    if (!token.empty()) {
+        body["token"] = token;
+    }
+
     const httplib::Headers headers = { {"User-Agent", "Mozilla/5.0"} };
 
     httplib::Result response =
         client.Post(path, headers, body.dump(), "application/json");
     if (!response) {
+        this->errorMessage = "Failed to connect to server (HTTPS). Check the address and port.";
         std::cout << "HTTPS error: unknown" << std::endl;
     } else if (response->status != Success) {
+        this->errorMessage = "HTTP " + std::to_string(response->status);
+        if (!response->reason.empty()) {
+            this->errorMessage += " - " + response->reason;
+        }
         std::cout << "HTTPS error: " << to_string(response.error())
             << std::endl;
     } else {
         std::cout << "HTTPS status: " << to_string(response.error())
             << std::endl;
-    }
-
-    if (response && response->status == Success &&
-        !parseJsonResponse(response->body)) {
-        response->status = -1;
     }
 
     return response;
@@ -256,28 +295,42 @@ httplib::Result LoginHttp::loginHttpJson(const std::string& host,
                                          const std::string& path,
                                          const uint16_t port,
                                          const std::string& email,
-                                         const std::string& password) {
+                                         const std::string& password,
+                                         const std::string& token) {
     httplib::Client client(host, port);
     client.set_logger(
         [this](const auto& req, const auto& res) { LoginHttp::Logger(req, res); });
 
     const httplib::Headers headers = { {"User-Agent", "Mozilla/5.0"} };
-    const json body = { {"email", email}, {"password", password}, {"stayloggedin", true}, {"type", "login"} };
+    json body = {
+        {"email", email},
+        {"password", password},
+        {"stayloggedin", true},
+        {"type", "login"}
+    };
+
+    if (!token.empty()) {
+        body["token"] = token;
+    }
 
     httplib::Result response =
         client.Post(path, headers, body.dump(), "application/json");
     if (!response) {
+        this->errorMessage = "Failed to connect to server (HTTP). Check the address and port.";
         std::cout << "HTTP error: unknown" << std::endl;
     } else if (response->status != Success) {
+        this->errorMessage = "HTTP " + std::to_string(response->status);
+        if (!response->reason.empty()) {
+            this->errorMessage += " - " + response->reason;
+        }
         std::cout << "HTTP error: " << to_string(response.error())
             << std::endl;
     } else {
         std::cout << "HTTP status: " << to_string(response.error())
             << std::endl;
     }
-    if (response && response->status == Success &&
-           !parseJsonResponse(response->body)) {
-        response->status = -1;
+    if (response && response->status == Success && !parseJsonResponse(response->body)) {
+        return response;
     }
 
     return response;
@@ -291,35 +344,30 @@ bool LoginHttp::parseJsonResponse(const std::string& body) {
         responseJson = json::parse(body);
     } catch (...) {
         g_logger.info("Failed to parse json response");
+        this->errorMessage = "Invalid response received from server (expected JSON).";
         return false;
     }
 
-    if (cancelled.load()) return false;
-    if (responseJson.contains("errorMessage")) {
-        this->errorMessage = to_string(responseJson.at("errorMessage"));
+    if (responseJson.contains("errorCode") && responseJson["errorCode"].get<int>() != 0) {
+        this->errorMessage = responseJson.value("errorMessage", "Authenticator token required.");
+        g_logger.error("Error code: {}, message: {}", responseJson["errorCode"].get<int>(), this->errorMessage);
         return false;
     }
 
-    if (!responseJson.contains("session")) {
-        g_logger.info("No session data");
+    if (!responseJson.contains("session") || !responseJson.contains("playdata")) {
+        this->errorMessage = "Missing session or playdata.";
         return false;
     }
 
-    if (responseJson.contains("playdata")) {
-        json playdata = responseJson.at("playdata");
-
-        this->characters = "{}";
-        if (playdata.contains("characters")) {
-            this->characters = to_string(playdata.at("characters"));
-        }
-
-        this->worlds = "{}";
-        if (playdata.contains("worlds")) {
-            this->worlds = to_string(playdata.at("worlds"));
-        }
+    json playdata = responseJson["playdata"];
+    if (!playdata.contains("characters") || !playdata.contains("worlds")) {
+        this->errorMessage = "Missing characters or worlds.";
+        return false;
     }
 
-    this->session = to_string(responseJson.at("session"));
+    this->session = to_string(responseJson["session"]);
+    this->characters = to_string(playdata["characters"]);
+    this->worlds = to_string(playdata["worlds"]);
 
     return true;
 }

--- a/src/framework/net/httplogin.h
+++ b/src/framework/net/httplogin.h
@@ -47,17 +47,19 @@ public:
 
     void httpLogin(const std::string& host, const std::string& path,
                    uint16_t port, const std::string& email,
-                   const std::string& password, int request_id, bool httpLogin);
+                   const std::string& password, int request_id, bool httpLogin, const std::string& token);
 
     httplib::Result loginHttpsJson(const std::string& host,
                                    const std::string& path, uint16_t port,
                                    const std::string& email,
-                                   const std::string& password);
+                                   const std::string& password,
+                                   const std::string& token);
 
     httplib::Result loginHttpJson(const std::string& host,
                                   const std::string& path, uint16_t port,
                                   const std::string& email,
-                                  const std::string& password);
+                                  const std::string& password,
+                                  const std::string& token);
 
     void cancel();
 


### PR DESCRIPTION
This pull request introduces multi-server configuration support and implements two-factor authentication (2FA) for login, along with improvements to account credential management and error handling. The most important changes are grouped below.

**Multi-server configuration and management:**

* Added a new `Servers_init` configuration system in `init.lua`, allowing clients to easily switch between multiple servers and worlds from a single installation. This includes an `ENABLE_SERVERS` flag to enable/disable the entire configuration block and per-server settings such as port, protocol, and authentication options. (`init.lua` [init.luaL12-R84](diffhunk://#diff-0fc5c43f6f1d7605fd7d16c088ba6b83f096eee8e2049517407bbaa27aa3a4f7L12-R84))

**Two-factor authentication (2FA) integration:**

* Introduced a new UI window for entering authentication tokens (`authenticatortoken.otui`), and added logic to prompt users for a token when required, including error handling for incorrect tokens. (`authenticatortoken.otui` [[1]](diffhunk://#diff-69dc2dcbae1fb38636e6d98a0506c43f790f9342ebe87eea78cc7a5f39adae0bR1-R67) `entergame.lua` [[2]](diffhunk://#diff-9069838e67c3d247571f4c3e3d140550eb63b59bdb21eb26222ba79ba312b9f7R27-R50) [[3]](diffhunk://#diff-9069838e67c3d247571f4c3e3d140550eb63b59bdb21eb26222ba79ba312b9f7R546) [[4]](diffhunk://#diff-9069838e67c3d247571f4c3e3d140550eb63b59bdb21eb26222ba79ba312b9f7R683-R697)
* Updated the login flow to support passing an authentication token to the backend, including changes to the HTTP login function signature and logic for token entry and error feedback. (`meta.lua` [[1]](diffhunk://#diff-5cbfb396d7e8dd9111cfc8ca5d904df3d1ea0498cc2355222a120e1d32b01cd3R3556-R3559) `entergame.lua` [[2]](diffhunk://#diff-9069838e67c3d247571f4c3e3d140550eb63b59bdb21eb26222ba79ba312b9f7L599-R663) [[3]](diffhunk://#diff-9069838e67c3d247571f4c3e3d140550eb63b59bdb21eb26222ba79ba312b9f7L725)

**Account credential management improvements:**

* Credentials are now stored and retrieved per-server, encrypted, and managed via the `ServerList` module. The UI updates automatically based on stored credentials, and the "Remember Email" checkbox is now server-specific. (`entergame.lua` [[1]](diffhunk://#diff-9069838e67c3d247571f4c3e3d140550eb63b59bdb21eb26222ba79ba312b9f7R89-R92) [[2]](diffhunk://#diff-9069838e67c3d247571f4c3e3d140550eb63b59bdb21eb26222ba79ba312b9f7L138-L139) [[3]](diffhunk://#diff-9069838e67c3d247571f4c3e3d140550eb63b59bdb21eb26222ba79ba312b9f7L155-R205) [[4]](diffhunk://#diff-9069838e67c3d247571f4c3e3d140550eb63b59bdb21eb26222ba79ba312b9f7L195-R268) [[5]](diffhunk://#diff-9069838e67c3d247571f4c3e3d140550eb63b59bdb21eb26222ba79ba312b9f7R313-R329) [[6]](diffhunk://#diff-9069838e67c3d247571f4c3e3d140550eb63b59bdb21eb26222ba79ba312b9f7L483-R569)
* Added a `safeDecrypt` helper to robustly handle decryption failures when loading credentials. (`entergame.lua` [modules/client_entergame/entergame.luaR3-R7](diffhunk://#diff-9069838e67c3d247571f4c3e3d140550eb63b59bdb21eb26222ba79ba312b9f7R3-R7))

**UI and error handling enhancements:**

* Improved error handling for authentication failures, including displaying error dialogs and managing focus for the token entry window. (`entergame.lua` [[1]](diffhunk://#diff-9069838e67c3d247571f4c3e3d140550eb63b59bdb21eb26222ba79ba312b9f7R27-R50) [[2]](diffhunk://#diff-9069838e67c3d247571f4c3e3d140550eb63b59bdb21eb26222ba79ba312b9f7R546)
* Refactored and cleaned up legacy code related to authentication token toggling and removed unused UI logic, simplifying the codebase. (`entergame.lua` [[1]](diffhunk://#diff-9069838e67c3d247571f4c3e3d140550eb63b59bdb21eb26222ba79ba312b9f7L505-L547) [[2]](diffhunk://#diff-9069838e67c3d247571f4c3e3d140550eb63b59bdb21eb26222ba79ba312b9f7L577)

**Server list and autologin support:**

* Added logic to load and show the server list UI, and improved autologin support by saving autologin preferences per server. (`entergame.lua` [[1]](diffhunk://#diff-9069838e67c3d247571f4c3e3d140550eb63b59bdb21eb26222ba79ba312b9f7R161-R168) [[2]](diffhunk://#diff-9069838e67c3d247571f4c3e3d140550eb63b59bdb21eb26222ba79ba312b9f7R313-R329)
