### PR TITLE
fix: #1460 Failed to fetch sprite

### DIFF
--- a/src/client/thingtype.cpp
+++ b/src/client/thingtype.cpp
@@ -758,23 +758,26 @@ void ThingType::loadTexture(const int animationPhase)
                                 return;
 
                             if (!spriteImage) {
-                                g_logger.error("Failed to fetch sprite id {} for thing {} ({}, {}), layer {}, pattern {}x{}x{}, frame {}", spriteId, m_name, m_id, categoryName(m_category), l, x, y, z, animationPhase);
-                                return;
+                                if (spriteId != 0) {
+                                    g_logger.error("Failed to fetch sprite id {} for thing {} ({}, {}), layer {}, pattern {}x{}x{}, frame {}", spriteId, m_name, m_id, categoryName(m_category), l, x, y, z, animationPhase);
+                                    return;
+                                }
+                                // sprite id 0 represents empty/transparent sprite, skip blitting but continue processing
+                            } else {
+                                // verifies that the first block in the lower right corner is transparent.
+                                if (spriteImage->hasTransparentPixel()) {
+                                    fullImage->setTransparentPixel(true);
+                                }
+
+                                if (spriteMask) {
+                                    spriteImage->overwriteMask(maskColors[(l - 1)]);
+                                }
+
+                                auto spriteSize = spriteImage->getSize() / g_gameConfig.getSpriteSize();
+
+                                const Point& spritePos = Point(m_size.width() - spriteSize.width(), m_size.height() - spriteSize.height()) * g_gameConfig.getSpriteSize();
+                                fullImage->blit(framePos + spritePos, spriteImage);
                             }
-
-                            // verifies that the first block in the lower right corner is transparent.
-                            if (!spriteImage || spriteImage->hasTransparentPixel()) {
-                                fullImage->setTransparentPixel(true);
-                            }
-
-                            if (spriteMask) {
-                                spriteImage->overwriteMask(maskColors[(l - 1)]);
-                            }
-
-                            auto spriteSize = spriteImage->getSize() / g_gameConfig.getSpriteSize();
-
-                            const Point& spritePos = Point(m_size.width() - spriteSize.width(), m_size.height() - spriteSize.height()) * g_gameConfig.getSpriteSize();
-                            fullImage->blit(framePos + spritePos, spriteImage);
                         } else {
                             for (int h = 0; h < m_size.height(); ++h) {
                                 for (int w = 0; w < m_size.width(); ++w) {
@@ -787,21 +790,24 @@ void ThingType::loadTexture(const int animationPhase)
                                         return;
 
                                     if (!spriteImage) {
-                                        g_logger.error("Failed to fetch sprite id {} for thing {} ({}, {}), layer {}, pattern {}x{}x{}, frame {}, offset {}x{}", spriteId, m_name, m_id, categoryName(m_category), l, x, y, z, framePos, w, h);
-                                        return;
-                                    }
+                                        if (spriteId != 0) {
+                                            g_logger.error("Failed to fetch sprite id {} for thing {} ({}, {}), layer {}, pattern {}x{}x{}, frame {}, offset {}x{}", spriteId, m_name, m_id, categoryName(m_category), l, x, y, z, framePos, w, h);
+                                            return;
+                                        }
+                                        // sprite id 0 represents empty/transparent sprite, skip blitting but continue processing
+                                    } else {
+                                        // verifies that the first block in the lower right corner is transparent.
+                                        if (h == 0 && w == 0 && spriteImage->hasTransparentPixel()) {
+                                            fullImage->setTransparentPixel(true);
+                                        }
 
-                                    // verifies that the first block in the lower right corner is transparent.
-                                    if (h == 0 && w == 0 && (!spriteImage || spriteImage->hasTransparentPixel())) {
-                                        fullImage->setTransparentPixel(true);
-                                    }
+                                        if (spriteMask) {
+                                            spriteImage->overwriteMask(maskColors[(l - 1)]);
+                                        }
 
-                                    if (spriteMask) {
-                                        spriteImage->overwriteMask(maskColors[(l - 1)]);
+                                        const Point& spritePos = Point(m_size.width() - w - 1, m_size.height() - h - 1) * g_gameConfig.getSpriteSize();
+                                        fullImage->blit(framePos + spritePos, spriteImage);
                                     }
-
-                                    const Point& spritePos = Point(m_size.width() - w - 1, m_size.height() - h - 1) * g_gameConfig.getSpriteSize();
-                                    fullImage->blit(framePos + spritePos, spriteImage);
                                 }
                             }
                         }

--- a/src/client/thingtype.cpp
+++ b/src/client/thingtype.cpp
@@ -762,7 +762,6 @@ void ThingType::loadTexture(const int animationPhase)
                                     g_logger.error("Failed to fetch sprite id {} for thing {} ({}, {}), layer {}, pattern {}x{}x{}, frame {}", spriteId, m_name, m_id, categoryName(m_category), l, x, y, z, animationPhase);
                                     return;
                                 }
-                                // sprite id 0 represents empty/transparent sprite, skip blitting but continue processing
                             } else {
                                 // verifies that the first block in the lower right corner is transparent.
                                 if (spriteImage->hasTransparentPixel()) {
@@ -794,7 +793,6 @@ void ThingType::loadTexture(const int animationPhase)
                                             g_logger.error("Failed to fetch sprite id {} for thing {} ({}, {}), layer {}, pattern {}x{}x{}, frame {}, offset {}x{}", spriteId, m_name, m_id, categoryName(m_category), l, x, y, z, framePos, w, h);
                                             return;
                                         }
-                                        // sprite id 0 represents empty/transparent sprite, skip blitting but continue processing
                                     } else {
                                         // verifies that the first block in the lower right corner is transparent.
                                         if (h == 0 && w == 0 && spriteImage->hasTransparentPixel()) {


### PR DESCRIPTION
It has been 2 days since the bug occurred, and I believe it is a **critical bug** that should be fixed as soon as possible.

# POSSIBLE FIX
**I propose this solution (temporary solution) until the author fixes it.**

(I'm a noob in c++.)

<img width="715" height="366" alt="image" src="https://github.com/user-attachments/assets/e02a4617-6f0c-4f9d-80fc-b8c8eb56961e" />

I confirm that it works on:
 
- [x] spr/dat 8.60
- [x] Assets 14.12

# fix:

https://github.com/mehah/otclient/issues/1460