### PR TITLE
fix: prevent ERROR: /game_battle/battle.lua:20: stack overflow

### DIFF
--- a/modules/game_battle/battle.lua
+++ b/modules/game_battle/battle.lua
@@ -13,22 +13,15 @@ BattleListInstance = nil
 BattleButtonPool = nil
 
 -- Utility functions
-function table.copy(t)
+function tableCopy(t)
     if type(t) ~= "table" then return t end
     local meta = getmetatable(t)
     local target = {}
     for k, v in pairs(t) do
-        target[k] = type(v) == "table" and table.copy(v) or v
+        target[k] = type(v) == "table" and tableCopy(v) or v
     end
     setmetatable(target, meta)
     return target
-end
-
-function table.size(t)
-    if type(t) ~= "table" then return 0 end
-    local count = 0
-    for _ in pairs(t) do count = count + 1 end
-    return count
 end
 
 -- Default filter settings
@@ -127,7 +120,7 @@ function BattleListManager:restoreInstancesState()
                 if instance and instance.window then
                     if shouldRestoreSettings and oldSettings then
                         local newSettingsKey = instance:getSettingsKey()
-                        local settingsToRestore = table.copy(oldSettings)
+                        local settingsToRestore = tableCopy(oldSettings)
                         settingsToRestore.customName = data.name
                         
                         g_settings.mergeNode(newSettingsKey, settingsToRestore)
@@ -456,7 +449,7 @@ function BattleListInstance:new(id, customName)
     instance.lastAge = 0
     instance.name = customName or tr('Battle List')
     instance.settings = {
-        filters = table.copy(BATTLE_FILTERS),
+        filters = tableCopy(BATTLE_FILTERS),
         sortType = 'name',
         sortOrder = 'A',
         hidingFilters = false,
@@ -473,7 +466,7 @@ end
 function BattleListInstance:loadFilters()
     local settings = g_settings.getNode(self:getSettingsKey())
     if not settings or not settings['filters'] then
-        return table.copy(BATTLE_FILTERS)
+        return tableCopy(BATTLE_FILTERS)
     end
     return settings['filters']
 end
@@ -682,7 +675,7 @@ function BattleListInstance:clearAllConfigurations()
     end
     
     self.settings = {
-        filters = table.copy(BATTLE_FILTERS),
+        filters = tableCopy(BATTLE_FILTERS),
         sortType = 'name',
         sortOrder = 'A',
         hidingFilters = false,


### PR DESCRIPTION
The problem was defined twice: table.copy(t) and function table.size(t).

modules/game_battle/battle.lua vs modules/corelib/table.lua

To ensure I didn't break anything in game_battle, I just changed the name to the variable., in modules/game_battle/battle.lua

```diff
- function table.copy(t)
+ function tableCopy(t)
```
https://github.com/user-attachments/assets/836dbc84-88c3-4eee-be93-0c5e72d52dff

<img width="391" height="113" alt="image" src="https://github.com/user-attachments/assets/f9ab584a-5817-4bef-936a-c4442f6ecfa5" />
