### PR TITLE
fix: compilation in FRAMEWORK_EDITOR

### DIFF
--- a/src/client/thing.cpp
+++ b/src/client/thing.cpp
@@ -260,7 +260,7 @@ bool Thing::blockProjectile() const {
     return false;
 }
 
-bool Thing::isContainer() {
+bool Thing::isContainer() const {
     if (const auto t = getThingType(); t)
         return t->isContainer();
     return false;

--- a/src/client/thing.h
+++ b/src/client/thing.h
@@ -99,7 +99,7 @@ public:
 
     bool blockProjectile() const;
 
-    virtual bool isContainer();
+    virtual bool isContainer() const;
 
     bool isTopGround();
     bool isTopGroundBorder();

--- a/src/client/thingtype.h
+++ b/src/client/thingtype.h
@@ -97,7 +97,7 @@ public:
     bool isGroundBorder() { return (m_flags & ThingFlagAttrGroundBorder); }
     bool isOnBottom() { return (m_flags & ThingFlagAttrOnBottom); }
     bool isOnTop() { return (m_flags & ThingFlagAttrOnTop); }
-    bool isContainer() { return (m_flags & ThingFlagAttrContainer); }
+    bool isContainer() const { return (m_flags & ThingFlagAttrContainer); }
     bool isStackable() { return (m_flags & ThingFlagAttrStackable); }
     bool isForceUse() { return (m_flags & ThingFlagAttrForceUse); }
     bool isMultiUse() { return (m_flags & ThingFlagAttrMultiUse); }

--- a/vc17/otclient.vcxproj
+++ b/vc17/otclient.vcxproj
@@ -274,7 +274,7 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='OpenGL|x64'">
     <ClCompile>
-      <PreprocessorDefinitions>$(PREPROCESSOR_DEFS);NDEBUG;FRAMEWORK_EDITOR</PreprocessorDefinitions>
+      <PreprocessorDefinitions>$(PREPROCESSOR_DEFS);NDEBUG;</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <EnableEnhancedInstructionSet>StreamingSIMDExtensions2</EnableEnhancedInstructionSet>
       <Optimization>MaxSpeed</Optimization>

--- a/vc17/otclient.vcxproj
+++ b/vc17/otclient.vcxproj
@@ -274,7 +274,7 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='OpenGL|x64'">
     <ClCompile>
-      <PreprocessorDefinitions>$(PREPROCESSOR_DEFS);NDEBUG;</PreprocessorDefinitions>
+      <PreprocessorDefinitions>$(PREPROCESSOR_DEFS);NDEBUG;FRAMEWORK_EDITOR</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <EnableEnhancedInstructionSet>StreamingSIMDExtensions2</EnableEnhancedInstructionSet>
       <Optimization>MaxSpeed</Optimization>


### PR DESCRIPTION
Compiling in FRAMEWORK_EDITOR mode fails with:

> C3668: Item::isContainer() marked override but doesn't override base class
> C2662: Cannot convert this pointer from const Item to Thing &

```cpp
1>unity_HP033YRVZXFMW2YE.cpp
1>D:\github\otclient.readme\src\client\item.h(151,10): error C3668: 'Item::isContainer': method with override specifier 'override' did not override any base class methods
1>(compiling source file '/otclient/x64/OpenGL/unity_5Y9NN2PYLTVGF2J1.cpp')
1>D:\github\otclient.readme\src\client\item.h(151,94): error C2662: 'bool Thing::isContainer(void)': cannot convert 'this' pointer from 'const Item' to 'Thing &'
1>(compiling source file '/otclient/x64/OpenGL/unity_5Y9NN2PYLTVGF2J1.cpp')
1> D:\github\otclient.readme\src\client\item.h(151,94):
1> Conversion loses qualifiers
1> D:\github\otclient.readme\src\client\thing.h(102,18):
1> see declaration of 'Thing::isContainer'
1> D:\github\otclient.readme\src\client\item.h(151,94):
1> while trying to match the argument list '()'
1>Done building project "otclient.vcxproj" -- FAILED.
```