### PR TITLE
fix: f(char*) f(std::string) + replace c_str() with data()

### DIFF
--- a/src/framework/util/color.cpp
+++ b/src/framework/util/color.cpp
@@ -163,7 +163,7 @@ namespace {
 
     static inline int parse_byte_or_percent(const std::string& s) {
         if (!s.empty() && s.back() == '%') {
-            const double p = std::strtod(s.c_str(), nullptr);
+            const double p = std::strtod(s.data(), nullptr);
             return clamp255(static_cast<int>(std::lround(p * 255.0 / 100.0)));
         }
         return clamp255(std::stoi(s));
@@ -171,11 +171,11 @@ namespace {
 
     static inline int parse_alpha_any(const std::string& s) {
         if (!s.empty() && s.back() == '%') {
-            const double p = std::strtod(s.c_str(), nullptr);
+            const double p = std::strtod(s.data(), nullptr);
             return clamp255(static_cast<int>(std::lround(p * 255.0 / 100.0)));
         }
         if (s.find_first_of(".eE") != std::string::npos) {
-            double f = std::strtod(s.c_str(), nullptr);
+            double f = std::strtod(s.data(), nullptr);
             if (f < 0) f = 0; if (f > 1) f = 1;
             return clamp255(static_cast<int>(std::lround(f * 255.0)));
         }
@@ -222,7 +222,7 @@ namespace {
 
 Color::Color(const std::string_view coltext)
 {
-    std::stringstream ss(coltext.data());
+    std::stringstream ss(std::string(coltext));
     ss >> *this;
     update();
 }
@@ -263,7 +263,7 @@ std::istream& operator>>(std::istream& in, Color& color)
 
     auto parse_byte_or_percent = [&](const std::string& s) {
         if (!s.empty() && s.back() == '%') {
-            const double p = std::strtod(s.c_str(), nullptr);
+            const double p = std::strtod(s.data(), nullptr);
             return clamp255(static_cast<int>(std::lround(p * 255.0 / 100.0)));
         }
         return clamp255(std::stoi(s));
@@ -271,11 +271,11 @@ std::istream& operator>>(std::istream& in, Color& color)
 
     auto parse_alpha_any = [&](const std::string& s) {
         if (!s.empty() && s.back() == '%') {
-            const double p = std::strtod(s.c_str(), nullptr);
+            const double p = std::strtod(s.data(), nullptr);
             return clamp255(static_cast<int>(std::lround(p * 255.0 / 100.0)));
         }
         if (s.find_first_of(".eE") != std::string::npos) {
-            double f = std::strtod(s.c_str(), nullptr);
+            double f = std::strtod(s.data(), nullptr);
             if (f < 0) f = 0; if (f > 1) f = 1;
             return clamp255(static_cast<int>(std::lround(f * 255.0)));
         }
@@ -372,9 +372,9 @@ std::istream& operator>>(std::istream& in, Color& color)
             if (o != std::string::npos && c != std::string::npos && c > o + 1) {
                 auto parts = split_commas(t.substr(o + 1, c - o - 1));
                 if ((!hasA && parts.size() == 3) || (hasA && parts.size() == 4)) {
-                    const double h = std::strtod(parts[0].c_str(), nullptr);
+                    const double h = std::strtod(parts[0].data(), nullptr);
                     auto pct = [](const std::string& s) {
-                        const double v = std::strtod(s.c_str(), nullptr);
+                        const double v = std::strtod(s.data(), nullptr);
                         return (!s.empty() && s.back() == '%') ? std::clamp(v / 100.0, 0.0, 1.0)
                             : std::clamp(v, 0.0, 1.0);
                     };

--- a/src/framework/util/color.cpp
+++ b/src/framework/util/color.cpp
@@ -222,7 +222,7 @@ namespace {
 
 Color::Color(const std::string_view coltext)
 {
-    std::stringstream ss(std::string(coltext));
+    std::stringstream ss((std::string(coltext)));
     ss >> *this;
     update();
 }

--- a/src/framework/util/crypt.cpp
+++ b/src/framework/util/crypt.cpp
@@ -164,12 +164,12 @@ std::string Crypt::_decrypt(const std::string& encrypted_string, const bool useM
 void Crypt::rsaSetPublicKey(const std::string& n, const std::string& e)
 {
 #ifdef USE_GMP
-    mpz_set_str(m_n, n.c_str(), 10);
-    mpz_set_str(m_e, e.c_str(), 10);
+    mpz_set_str(m_n, n.data(), 10);
+    mpz_set_str(m_e, e.data(), 10);
 #else
     BIGNUM* bn = nullptr, * be = nullptr;
-    BN_dec2bn(&bn, n.c_str());
-    BN_dec2bn(&be, e.c_str());
+    BN_dec2bn(&bn, n.data());
+    BN_dec2bn(&be, e.data());
     RSA_set0_key(m_rsa, bn, be, nullptr);
 #endif
 }
@@ -177,17 +177,17 @@ void Crypt::rsaSetPublicKey(const std::string& n, const std::string& e)
 void Crypt::rsaSetPrivateKey(const std::string& p, const std::string& q, const std::string& d)
 {
 #ifdef USE_GMP
-    mpz_set_str(m_p, p, 10);
-    mpz_set_str(m_q, q, 10);
-    mpz_set_str(m_d, d, 10);
+    mpz_set_str(m_p, p.data(), 10);
+    mpz_set_str(m_q, q.data(), 10);
+    mpz_set_str(m_d, d.data(), 10);
 
     // n = p * q
     mpz_mul(m_n, m_p, m_q);
 #else
 #if OPENSSL_VERSION_NUMBER < 0x10100005L
-    BN_dec2bn(&m_rsa->p, p);
-    BN_dec2bn(&m_rsa->q, q);
-    BN_dec2bn(&m_rsa->d, d);
+    BN_dec2bn(&m_rsa->p, p.data());
+    BN_dec2bn(&m_rsa->q, q.data());
+    BN_dec2bn(&m_rsa->d, d.data());
     // clear rsa cache
     if (m_rsa->_method_mod_p) {
         BN_MONT_CTX_free(m_rsa->_method_mod_p);
@@ -199,9 +199,9 @@ void Crypt::rsaSetPrivateKey(const std::string& p, const std::string& q, const s
     }
 #else
     BIGNUM* bp = nullptr, * bq = nullptr, * bd = nullptr;
-    BN_dec2bn(&bp, p.c_str());
-    BN_dec2bn(&bq, q.c_str());
-    BN_dec2bn(&bd, d.c_str());
+    BN_dec2bn(&bp, p.data());
+    BN_dec2bn(&bq, q.data());
+    BN_dec2bn(&bd, d.data());
     RSA_set0_key(m_rsa, nullptr, nullptr, bd);
     RSA_set0_factors(m_rsa, bp, bq);
 #endif
@@ -275,7 +275,7 @@ int Crypt::rsaGetSize()
 std::string Crypt::crc32(const std::string& decoded_string, const bool upperCase)
 {
     uint32_t crc = ::crc32(0, nullptr, 0);
-    crc = ::crc32(crc, (const Bytef*)decoded_string.c_str(), decoded_string.size());
+    crc = ::crc32(crc, reinterpret_cast<const Bytef*>(decoded_string.data()), decoded_string.size());
     std::string result = stdext::dec_to_hex(crc);
     if (upperCase)
         std::ranges::transform(result, result.begin(), toupper);


### PR DESCRIPTION
was some bugs where we were sending std::string or std::string_view directly to C apis taking char*

I'm honestly surprised that compiled at all, the compiler should have refused to compile it, or at least complained.
I am guessing USE_GMP's Crypt::rsaSetPrivateKey has been broken since 8a17e720ec173ccbeb3edd5e3f7d99c80e4eec4e but nobody noticed.

also a nitpick in Color::Color(const std::string_view coltext), 
- if coltext is not null-terminated, the old implementation would do a buffer-overread. It was effectively doing strlen() regardless of how long coltext was. It's *possible* that the strlen() approach is a is an undocumented micro-optimization, but if that's the case, it should be clearly explained in a comment.

Also replaced a bunch of c_str() with data()
- As of C++11, for std::string, c_str() and data() are aliases of each other, doing the exact same thing (and even prior to C++11, they did the exact same thing, although it was not guaranteed by the c++ standard)
- std::string_view does not support c_str() at all, and only have data(), and thus I actually find it to be a larger cognitive load to review code using c_str() than data(), i have to keep in mind "are we using string or string_view here?" when reviewing c_str(), but when reviewing data(), I don't have to care, it doesn't matter.


## Type of change

Please delete options that are not relevant.

  - [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

  - [ ] Test A
  - [ ] Test B

**Test Configuration**:

  - Server Version: customized YurOTS 0.9.4F
  - Client: git custom build? 4.0b4+git?
  - Operating System: Windows 10 x64 22H2

## Checklist

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [ ] I checked the PR checks reports
  - [ ] I have commented my code, particularly in hard-to-understand areas
  - [ ] I have made corresponding changes to the documentation
  - [ ] My changes generate no new warnings
  - [ ] I have added tests that prove my fix is effective or that my feature works
