### PR TITLE
fix: capacity scaling for 7.6 protocol

### DIFF
--- a/src/client/protocolgameparse.cpp
+++ b/src/client/protocolgameparse.cpp
@@ -2321,7 +2321,7 @@ void ProtocolGame::parsePlayerStats(const InputMessagePtr& msg) const
     const uint32_t maxHealth = g_game.getFeature(Otc::GameDoubleHealth) ? msg->getU32() : msg->getU16();
     uint32_t freeCapacity = g_game.getFeature(Otc::GameDoubleFreeCapacity) ? msg->getU32() : msg->getU16();
     if (g_game.getClientVersion() >= 772) {
-        // todo: We only know scaling started some time after 7.6; the 760 cutoff is a placeholder until we find the exact version.
+        // todo: We only know scaling started some time after 7.72; the 772 cutoff is a placeholder until we find the exact version.
         freeCapacity /= 100;
     }
 

--- a/src/client/protocolgameparse.cpp
+++ b/src/client/protocolgameparse.cpp
@@ -2320,7 +2320,7 @@ void ProtocolGame::parsePlayerStats(const InputMessagePtr& msg) const
     const uint32_t health = g_game.getFeature(Otc::GameDoubleHealth) ? msg->getU32() : msg->getU16();
     const uint32_t maxHealth = g_game.getFeature(Otc::GameDoubleHealth) ? msg->getU32() : msg->getU16();
     uint32_t freeCapacity = g_game.getFeature(Otc::GameDoubleFreeCapacity) ? msg->getU32() : msg->getU16();
-    if (g_game.getClientVersion() >= 772) {
+    if (g_game.getClientVersion() > 772) {
         // todo: We only know scaling started some time after 7.72; the 772 cutoff is a placeholder until we find the exact version.
         freeCapacity /= 100;
     }

--- a/src/client/protocolgameparse.cpp
+++ b/src/client/protocolgameparse.cpp
@@ -2320,7 +2320,7 @@ void ProtocolGame::parsePlayerStats(const InputMessagePtr& msg) const
     const uint32_t health = g_game.getFeature(Otc::GameDoubleHealth) ? msg->getU32() : msg->getU16();
     const uint32_t maxHealth = g_game.getFeature(Otc::GameDoubleHealth) ? msg->getU32() : msg->getU16();
     uint32_t freeCapacity = g_game.getFeature(Otc::GameDoubleFreeCapacity) ? msg->getU32() : msg->getU16();
-    if (g_game.getClientVersion() > 760) {
+    if (g_game.getClientVersion() >= 772) {
         // todo: We only know scaling started some time after 7.6; the 760 cutoff is a placeholder until we find the exact version.
         freeCapacity /= 100;
     }

--- a/src/client/protocolgameparse.cpp
+++ b/src/client/protocolgameparse.cpp
@@ -2319,7 +2319,11 @@ void ProtocolGame::parsePlayerStats(const InputMessagePtr& msg) const
 {
     const uint32_t health = g_game.getFeature(Otc::GameDoubleHealth) ? msg->getU32() : msg->getU16();
     const uint32_t maxHealth = g_game.getFeature(Otc::GameDoubleHealth) ? msg->getU32() : msg->getU16();
-    const uint32_t freeCapacity = g_game.getFeature(Otc::GameDoubleFreeCapacity) ? msg->getU32() / 100.f : msg->getU16() / 100.f;
+    uint32_t freeCapacity = g_game.getFeature(Otc::GameDoubleFreeCapacity) ? msg->getU32() : msg->getU16();
+    if (g_game.getClientVersion() > 760) {
+        // todo: We only know scaling started some time after 7.6; the 760 cutoff is a placeholder until we find the exact version.
+        freeCapacity /= 100;
+    }
 
     uint32_t totalCapacity = 0;
     if (g_game.getClientVersion() < 1281 && g_game.getFeature(Otc::GameTotalCapacity)) {


### PR DESCRIPTION
# Description

On tibia7.6 when my cap is in the 300s, mehah/otclient will just show "cap 3".

For example, my real cap is 321, and otclient just show cap 3.

Observed on the ot server tibiafun.hopto.org on 4.0b4 and git master build

(Actually I think this bug has been around for a long time and I just never bothered reporting it)


<img width="626" height="505" alt="Image" src="https://github.com/user-attachments/assets/91197004-c6b4-4335-8354-c323919436c0" />

<img width="1024" height="676" alt="Image" src="https://github.com/user-attachments/assets/10439155-142d-4ac6-8327-393c04db2b08" />


## Behavior

cap displayed is 3

### **Actual**

have 321 cap

### **Expected**

show 321 cap

## Fixes

resolves https://github.com/mehah/otclient/issues/1487


## Type of change

  - [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

  - [ ] Test A
  - [ ] Test B

**Test Configuration**:

  - Server Version: modified YurOTS 0.9.4F
  - Client: 4.0b4
  - Operating System: Windows 10 x64 22H2

## Checklist

  - [ ] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [ ] I checked the PR checks reports
  - [x] I have commented my code, particularly in hard-to-understand areas
  - [ ] I have made corresponding changes to the documentation
  - [ ] My changes generate no new warnings
  - [ ] I have added tests that prove my fix is effective or that my feature works
