### PR TITLE
fix: optimize color tolower

### DIFF
--- a/src/framework/util/color.cpp
+++ b/src/framework/util/color.cpp
@@ -131,14 +131,17 @@ namespace {
         {"yellow",rgb_to_abgr(0xFFFF00)}, {"yellowgreen",rgb_to_abgr(0x9ACD32)},
     };
 
-    inline std::string to_lower(std::string_view s) {
-        std::string out; out.reserve(s.size());
-        for (unsigned char c : s) out.push_back(std::tolower(c));
+    inline std::string to_lower_ascii(std::string_view s) {
+        std::string out(s);
+        for (char &c : out)
+            if (c >= 'A' && c <= 'Z')
+                c |= 0x20;
         return out;
     }
 
+
     inline bool css_lookup(std::string_view name, uint32_t& abgrOut) {
-        const auto key = to_lower(name);
+        const auto key = to_lower_ascii(name);
 
         if (key == "transparent") { abgrOut = 0x00000000u; return true; }
 


### PR DESCRIPTION
This is much faster because std::tolower(c) is locale-aware, while css colors/functions are ascii:
https://quick-bench.com/q/7-mFbZVV39_xWFZb9jEDKgtANcM
<img width="869" height="531" alt="image" src="https://github.com/user-attachments/assets/eced7b7d-94dd-4a20-8e45-5ab380a86c79" />


Also I did an attempt at significant optimizations to color.cpp using stringview (and stringview-trim)++ but had difficulty making it completely backwards-compatible, and gave up. ( https://github.com/mehah/otclient/commit/cedd34eb846f6a915ca7e223daee191c547fb473 )  oops.