### PR TITLE
fix: allow tibia7.6 to walk down more stairs

### DIFF
--- a/modules/game_walk/walk.lua
+++ b/modules/game_walk/walk.lua
@@ -58,8 +58,8 @@ local function canChangeFloor(pos, deltaZ)
     local toTile = g_map.getTile(toPos)
 
     if deltaZ > 0 then
-        -- Going DOWN: just check if destination is walkable (can step down onto it)
-        return toTile and toTile:isWalkable() and toTile:hasElevation(3)
+        -- Going DOWN
+        return toTile and toTile:isWalkable() and (toTile:hasElevation(3) or toTile:hasFloorChange())
     elseif deltaZ < 0 then
         -- Going UP: check if current tile has elevation (stairs to climb) AND destination is walkable
         return fromTile and fromTile:hasElevation(3) and toTile and toTile:isWalkable()


### PR DESCRIPTION
# Description

partial fix for https://github.com/mehah/otclient/issues/1422

with this, the 7.6 client can walk down more stairs. Not all stairs,  seemingly the tibia.dat for 7.6 is missing some floorChange  attributes, Or at least the tibia.dat from https://download.otservlist.org/client/tibia76.zip is missing some floorChange  attributes. 

fwiw published a manually patched tibia.dat at https://github.com/mehah/otclient/issues/1422#issuecomment-3674411643


## Behavior

mehah/otclient (but not edubart/otclient nor otclientv8) is unable to walk down lots of stairs on tibia7.6:
<img width="548" height="449" alt="Image" src="https://github.com/user-attachments/assets/7b0b2215-cd46-4d6a-8eb7-8d5dbd50ed15" />
<img width="147" height="309" alt="Image" src="https://github.com/user-attachments/assets/5cbc973f-14a1-40cf-b92e-f7139a8bba33" />


### **Actual**

Impossible to walk down stairs south of spawning point on tibiafun.hopto.org

### **Expected**

Should be able to walk down stairs south of spawning point on tibiafun.hopto.org

## Fixes

(not a complete fix, but a partial fix for #1422 )

## Type of change

Please delete options that are not relevant.

  - [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested

Walking down stairs south of spawning point on tibiafun.hopto.org

**Test Configuration**:

  - Server Version: (modified YurOTS 0.9.4F?)
  - Client: git master
  - Operating System: Windows 10 x64 sp1

## Checklist

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [x] I checked the PR checks reports
  - [ ] I have commented my code, particularly in hard-to-understand areas
  - [ ] I have made corresponding changes to the documentation
  - [x] My changes generate no new warnings
  - [ ] I have added tests that prove my fix is effective or that my feature works
