### PR TITLE
fix: handle floor-change tiles in walk logic

### DIFF
--- a/modules/game_walk/walk.lua
+++ b/modules/game_walk/walk.lua
@@ -48,24 +48,28 @@ end
 
 --- Generalized floor change check.
 local function canChangeFloor(pos, deltaZ)
+    if deltaZ == 0 then
+        return false
+    end
     local player = g_game.getLocalPlayer()
     if not player then
         return false
     end
 
-    local fromTile = g_map.getTile(player:getPosition())
     local toPos = {x = pos.x, y = pos.y, z = pos.z + deltaZ}
     local toTile = g_map.getTile(toPos)
-
-    if deltaZ > 0 then
-        -- Going DOWN: just check if destination is walkable (can step down onto it)
-        return toTile and toTile:isWalkable() and toTile:hasElevation(3)
-    elseif deltaZ < 0 then
-        -- Going UP: check if current tile has elevation (stairs to climb) AND destination is walkable
-        return fromTile and fromTile:hasElevation(3) and toTile and toTile:isWalkable()
+    if not toTile then
+        return false
     end
 
-    return false
+    if deltaZ > 0 then
+        -- Going DOWN
+        return toTile:isWalkable() and (toTile:hasElevation(3) or toTile:hasFloorChange())
+    end
+    -- deltaZ < 0
+    -- Going UP: check if current tile has elevation (stairs to climb) AND destination is walkable
+    local fromTile = g_map.getTile(player:getPosition())
+    return fromTile and fromTile:hasElevation(3) and toTile:isWalkable()
 end
 
 --- Makes the player walk in the given direction.

--- a/src/client/const.h
+++ b/src/client/const.h
@@ -1030,6 +1030,7 @@ enum ThingFlagAttr :uint64_t
     ThingFlagAttrDecoKit = static_cast<uint64_t>(1) << 45,
     ThingFlagAttrNPC = static_cast<uint64_t>(1) << 46,
     ThingFlagAttrAmmo = static_cast<uint64_t>(1) << 47,
+    ThingFlagAttrFloorChange = static_cast<uint64_t>(1) << 48,
 };
 
 enum STACK_PRIORITY : uint8_t

--- a/src/client/luafunctions.cpp
+++ b/src/client/luafunctions.cpp
@@ -702,6 +702,7 @@ void Client::registerLuaFunctions()
     g_lua.bindClassMemberFunction<ThingType>("isTranslucent", &ThingType::isTranslucent);
     g_lua.bindClassMemberFunction<ThingType>("hasDisplacement", &ThingType::hasDisplacement);
     g_lua.bindClassMemberFunction<ThingType>("hasElevation", &ThingType::hasElevation);
+    g_lua.bindClassMemberFunction<ThingType>("hasFloorChange", &ThingType::hasFloorChange);
     g_lua.bindClassMemberFunction<ThingType>("isLyingCorpse", &ThingType::isLyingCorpse);
     g_lua.bindClassMemberFunction<ThingType>("isAnimateAlways", &ThingType::isAnimateAlways);
     g_lua.bindClassMemberFunction<ThingType>("hasMiniMapColor", &ThingType::hasMiniMapColor);
@@ -926,6 +927,7 @@ void Client::registerLuaFunctions()
     g_lua.bindClassMemberFunction<Tile>("getGround", &Tile::getGround);
     g_lua.bindClassMemberFunction<Tile>("isWalkable", &Tile::isWalkable);
     g_lua.bindClassMemberFunction<Tile>("hasElevation", &Tile::hasElevation);
+    g_lua.bindClassMemberFunction<Tile>("hasFloorChange", &Tile::hasFloorChange);
 
     g_lua.bindClassMemberFunction<Tile>("isCovered", &Tile::isCovered);
     g_lua.bindClassMemberFunction<Tile>("isCompletelyCovered", &Tile::isCompletelyCovered);

--- a/src/client/thing.cpp
+++ b/src/client/thing.cpp
@@ -498,6 +498,13 @@ bool Thing::hasElevation() const {
         return t->hasElevation();
     return false;
 }
+bool Thing::hasFloorChange()
+{
+    if (const auto t = getThingType(); t)
+        return t->hasFloorChange();
+    return false;
+}
+
 bool Thing::hasAction() const {
     if (const auto t = getThingType(); t)
         return t->hasAction();

--- a/src/client/thing.cpp
+++ b/src/client/thing.cpp
@@ -498,7 +498,7 @@ bool Thing::hasElevation() const {
         return t->hasElevation();
     return false;
 }
-bool Thing::hasFloorChange()
+bool Thing::hasFloorChange() const
 {
     if (const auto t = getThingType(); t)
         return t->hasFloorChange();

--- a/src/client/thing.h
+++ b/src/client/thing.h
@@ -149,7 +149,7 @@ public:
     bool hasLensHelp() const;
     bool hasDisplacement() const;
     bool hasElevation() const;
-    bool hasFloorChange();
+    bool hasFloorChange() const;
     bool hasAction() const;
     bool hasWearOut() const;
     bool hasClockExpire() const;

--- a/src/client/thing.h
+++ b/src/client/thing.h
@@ -149,6 +149,7 @@ public:
     bool hasLensHelp() const;
     bool hasDisplacement() const;
     bool hasElevation() const;
+    bool hasFloorChange();
     bool hasAction() const;
     bool hasWearOut() const;
     bool hasClockExpire() const;

--- a/src/client/thingtype.cpp
+++ b/src/client/thingtype.cpp
@@ -113,6 +113,10 @@ void ThingType::unserializeAppearance(const uint16_t clientId, const ThingCatego
 
 void ThingType::applyAppearanceFlags(const appearances::AppearanceFlags& flags)
 {
+    if (flags.floorchange()) {
+        m_flags |= ThingFlagAttrFloorChange;
+    }
+
     if (flags.has_bank()) {
         m_groundSpeed = flags.bank().waypoints();
         m_flags |= ThingFlagAttrGround;
@@ -946,6 +950,7 @@ ThingFlagAttr ThingType::thingAttrToThingFlagAttr(const ThingAttr attr) {
         case ThingAttrDisplacement: return ThingFlagAttrDisplacement;
         case ThingAttrLight: return ThingFlagAttrLight;
         case ThingAttrElevation: return ThingFlagAttrElevation;
+        case ThingAttrFloorChange: return ThingFlagAttrFloorChange;
         case ThingAttrGround: return ThingFlagAttrGround;
         case ThingAttrWritable: return ThingFlagAttrWritable;
         case ThingAttrWritableOnce: return ThingFlagAttrWritableOnce;

--- a/src/client/thingtype.h
+++ b/src/client/thingtype.h
@@ -120,6 +120,7 @@ public:
     bool isTranslucent() { return (m_flags & ThingFlagAttrTranslucent); }
     bool hasDisplacement() { return (m_flags & ThingFlagAttrDisplacement); }
     bool hasElevation() { return (m_flags & ThingFlagAttrElevation); }
+    bool hasFloorChange() { return (m_flags & ThingFlagAttrFloorChange); }
     bool isLyingCorpse() { return (m_flags & ThingFlagAttrLyingCorpse); }
     bool isAnimateAlways() { return (m_flags & ThingFlagAttrAnimateAlways); }
     bool hasMiniMapColor() { return (m_flags & ThingFlagAttrMinimapColor); }

--- a/src/client/thingtype.h
+++ b/src/client/thingtype.h
@@ -120,7 +120,7 @@ public:
     bool isTranslucent() { return (m_flags & ThingFlagAttrTranslucent); }
     bool hasDisplacement() { return (m_flags & ThingFlagAttrDisplacement); }
     bool hasElevation() { return (m_flags & ThingFlagAttrElevation); }
-    bool hasFloorChange() { return (m_flags & ThingFlagAttrFloorChange); }
+    bool hasFloorChange() const { return (m_flags & ThingFlagAttrFloorChange); }
     bool isLyingCorpse() { return (m_flags & ThingFlagAttrLyingCorpse); }
     bool isAnimateAlways() { return (m_flags & ThingFlagAttrAnimateAlways); }
     bool hasMiniMapColor() { return (m_flags & ThingFlagAttrMinimapColor); }

--- a/src/client/tile.cpp
+++ b/src/client/tile.cpp
@@ -484,6 +484,14 @@ ThingPtr Tile::getTopThing()
 
 bool Tile::hasGround() { return (getGround() && getGround()->isSingleGround()) || m_thingTypeFlag & HAS_GROUND_BORDER; };
 bool Tile::hasTopGround(const bool ignoreBorder) { return (getGround() && getGround()->isTopGround()) || (!ignoreBorder && m_thingTypeFlag & HAS_TOP_GROUND_BORDER); }
+bool Tile::hasFloorChange()
+{
+    for (const auto& thing : m_things) {
+        if (thing->hasFloorChange())
+            return true;
+    }
+    return false;
+}
 ItemPtr Tile::getGround() { const auto& ground = getThing(0); return ground && ground->isGround() ? ground->static_self_cast<Item>() : nullptr; }
 
 std::vector<ItemPtr> Tile::getItems()

--- a/src/client/tile.cpp
+++ b/src/client/tile.cpp
@@ -484,7 +484,7 @@ ThingPtr Tile::getTopThing()
 
 bool Tile::hasGround() { return (getGround() && getGround()->isSingleGround()) || m_thingTypeFlag & HAS_GROUND_BORDER; };
 bool Tile::hasTopGround(const bool ignoreBorder) { return (getGround() && getGround()->isTopGround()) || (!ignoreBorder && m_thingTypeFlag & HAS_TOP_GROUND_BORDER); }
-bool Tile::hasFloorChange()
+bool Tile::hasFloorChange() const
 {
     for (const auto& thing : m_things) {
         if (thing->hasFloorChange())

--- a/src/client/tile.h
+++ b/src/client/tile.h
@@ -126,7 +126,7 @@ public:
     }
 
     bool hasElevation(const int elevation = 1) { return m_elevation >= elevation; }
-    bool hasFloorChange();
+    bool hasFloorChange() const;
 
 #ifdef FRAMEWORK_EDITOR
     void overwriteMinimapColor(uint8_t color) { m_minimapColor = color; }

--- a/src/client/tile.h
+++ b/src/client/tile.h
@@ -126,6 +126,7 @@ public:
     }
 
     bool hasElevation(const int elevation = 1) { return m_elevation >= elevation; }
+    bool hasFloorChange();
 
 #ifdef FRAMEWORK_EDITOR
     void overwriteMinimapColor(uint8_t color) { m_minimapColor = color; }

--- a/src/protobuf/appearances.proto
+++ b/src/protobuf/appearances.proto
@@ -190,6 +190,7 @@ message AppearanceFlags {
 	optional bool hook_south = 70;
 	optional bool hook_east = 71;
 	optional AppearanceFlagTransparencyLevel transparencylevel = 72;
+	optional bool floorchange = 73;
 }
 
 message AppearanceFlagUpgradeClassification {


### PR DESCRIPTION



# Description

Propagate ThingAttrFloorChange into flags/tiles/Lua and use it when deciding whether to step between floors.

partially fix https://github.com/mehah/otclient/issues/1422 this allows walking down more floors on 7.6
(but not all - seems some floors are missing the floorChange attribute in tibia.dat ? at least the bundle from https://download.otservlist.org/client/tibia76.zip seems to have some floors missing the floorChange attribute. )

## Behavior

Trying to walk down the floors south of spawning point on tibiafun.hopto.org
<img width="147" height="309" alt="Image" src="https://github.com/user-attachments/assets/5cbc973f-14a1-40cf-b92e-f7139a8bba33" />


### **Actual**

mehah/otclient refuse to walk down the stairs.


### **Expected**

should walk down the stairs

## Fixes

(partially fixes 1422 ?)

## Type of change

Please delete options that are not relevant.

  - [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested

Walk down stairs south of spawn on http://tibiafun.hotop.org

**Test Configuration**:

  - Server Version: (Modified YurOTS0.9.4F?)
  - Client: git  master, protocol 760
  - Operating System: Both Ubuntu24.04 and Windows 10

## Checklist

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [x] I checked the PR checks reports
  - [ ] I have commented my code, particularly in hard-to-understand areas
  - [ ] I have made corresponding changes to the documentation
  - [x] My changes generate no new warnings
  - [ ] I have added tests that prove my fix is effective or that my feature works
