### PR TITLE
fix: Adding datdump cpp/h to vcxproj

### DIFF
--- a/vc17/otclient.vcxproj
+++ b/vc17/otclient.vcxproj
@@ -501,6 +501,7 @@
     <ClCompile Include="..\src\framework\util\color.cpp" />
     <ClCompile Include="..\src\framework\util\crypt.cpp" />
     <ClCompile Include="..\src\main.cpp" />
+    <ClCompile Include="..\src\tools\datdump.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\src\client\animatedtext.h" />
@@ -694,6 +695,7 @@
     <ClInclude Include="..\src\framework\util\size.h" />
     <ClInclude Include="..\src\framework\util\spinlock.h" />
     <ClInclude Include="..\src\gitinfo.h" />
+    <ClInclude Include="..\src\tools\datdump.h" />
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="..\src\otcicon.rc" />


### PR DESCRIPTION
# Description

On the latest commit (318ed83), visual studio compiling broke due to datdump.cpp and datdump.h not being added to the solution.

## Behavior

### **Actual**

Does not compile due to linker errors

### **Expected**

Successfully compiles.

## Fixes

\# (issue)

## Type of change

Please delete options that are not relevant.

  - [X] Bug fix (non-breaking change which fixes an issue)
  - [ ] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [ ] This change requires a documentation update

## How Has This Been Tested

It compiles.
