### PR TITLE
fix: detection of Vorbis, VorbisFile and OGG in CMake for non-Windows targets

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -164,7 +164,7 @@ if(TOGGLE_FRAMEWORK_SOUND)
   if(NOT WASM)
     find_package(OpenAL CONFIG REQUIRED)
   endif()
-  if(NOT WIN32)
+  if(NOT WIN32 AND NOT WASM)
     pkg_check_modules(VORBISFILE REQUIRED vorbisfile)
     add_library(Vorbis::vorbisfile INTERFACE IMPORTED)
     set_target_properties(Vorbis::vorbisfile PROPERTIES

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -164,9 +164,32 @@ if(TOGGLE_FRAMEWORK_SOUND)
   if(NOT WASM)
     find_package(OpenAL CONFIG REQUIRED)
   endif()
-  find_package(VorbisFile REQUIRED)
-  find_package(Vorbis CONFIG REQUIRED)
-  find_package(Ogg CONFIG REQUIRED)
+  if(NOT WIN32)
+    pkg_check_modules(VORBISFILE REQUIRED vorbisfile)
+    add_library(Vorbis::vorbisfile INTERFACE IMPORTED)
+    set_target_properties(Vorbis::vorbisfile PROPERTIES
+        INTERFACE_INCLUDE_DIRECTORIES "${VORBISFILE_INCLUDE_DIRS}"
+        INTERFACE_LINK_LIBRARIES "${VORBISFILE_LIBRARIES}"
+    )
+
+    pkg_check_modules(VORBIS REQUIRED vorbis)
+    add_library(Vorbis::vorbis INTERFACE IMPORTED)
+    set_target_properties(Vorbis::vorbis PROPERTIES
+        INTERFACE_INCLUDE_DIRECTORIES "${VORBIS_INCLUDE_DIRS}"
+        INTERFACE_LINK_LIBRARIES "${VORBIS_LIBRARIES}"
+    )
+
+    pkg_check_modules(OGG REQUIRED ogg)
+    add_library(Ogg::ogg INTERFACE IMPORTED)
+    set_target_properties(Ogg::ogg PROPERTIES
+      INTERFACE_INCLUDE_DIRECTORIES "${OGG_INCLUDE_DIRS}"
+      INTERFACE_LINK_LIBRARIES "${OGG_LIBRARIES}"
+    )
+  else()
+    find_package(VorbisFile REQUIRED)
+    find_package(Vorbis CONFIG REQUIRED)
+    find_package(Ogg CONFIG REQUIRED)
+  endif()
 endif()
 if(ANDROID)
   set(LUA_LIBRARY ${LUA_LIBRARY} ${Android_LIBRARIES}/liblua.a)


### PR DESCRIPTION
# Description

Summary:
If a non-Windows target is detected by CMake, then Vorbis, VorbisFile and OGG will not be added by `find_package`, but by `pkg_check_modules`. In order to bridge the gap between these two methods in a way that doesn't break CMake later during source configuration, each library must also pass through `add_library` and `set_target_properties`.

Motivation:
I want to package OTClient for Gentoo in my own overlay because I have a personal use for it.

Context:
You'll be hard-pressed to find a Linux distribution that ships Vorbis, VorbisFile and OGG with their CMake helper files. The reason for this is that Vorbis' CMake build system is deprecated. Try to touch it with anything recent (I'm using CMake 4.1.2), and it'll result in an error with an explanation, that support for CMake 3.5 is deprecated and will be disabled soon. Depending on Vorbis' CMake infrastructure is not a sustainable strategy for package maintainers in basically every Linux distribution. If this was the only way to compile those libraries, they would find themselves unable to be used on Linux distributions that upgrade to a version of CMake that eventually drops this functionality entirely.

Dependencies:
No extra dependencies are required.

## Behavior

### **Actual**

When attempting to configure the source code of OTClient, this error will occur:
```
-- Enabled: ipo
-- Found Protobuf Compiler: /usr/bin/protoc
-- Use precompiled header: ON
-- Enabled: Build unity for speed up compilation
-- Disabled: asan
-- Disabled: DEBUG LOG
-- Build type: 
-- Build commit: 
-- Build revision: 
CMake Error at src/CMakeLists.txt:219 (find_package):
  Could not find a package configuration file provided by "Vorbis" with any
  of the following names:

    VorbisConfig.cmake
    vorbis-config.cmake

  Add the installation prefix of "Vorbis" to CMAKE_PREFIX_PATH or set
  "Vorbis_DIR" to a directory containing one of the above files.  If "Vorbis"
  provides a separate development package or SDK, be sure it has been
  installed.


-- Configuring incomplete, errors occurred!
```

### **Expected**

The source configuration stage should always complete without errors.

## Fixes

#1507

## Type of change

  - [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested

In order to test this change, create a directory called `build` in the source tree, `cd` into it, and run `cmake ..`. Source configuration should perform without any siginificant issues and result in a similar message as the one posted below.

```
-- The C compiler identification is GNU 15.2.1
-- The CXX compiler identification is GNU 15.2.1
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /usr/bin/cc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /usr/bin/c++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Enabled: ipo
-- Found Protobuf: /usr/lib64/libprotobuf.so (found version "6.31.1")
-- Found Threads: TRUE
-- Found Protobuf Compiler: /usr/bin/protoc
-- Use precompiled header: ON
-- Enabled: Build unity for speed up compilation
-- Disabled: asan
-- Disabled: DEBUG LOG
-- Build type: 
-- Build commit: 
-- Build revision: 
-- Found ZLIB: /usr/lib64/libz.so (found version "1.3.1")
-- Looking for C++ include parallel_hashmap/phmap.h
-- Looking for C++ include parallel_hashmap/phmap.h - found
-- Looking for C++ include parallel_hashmap/btree.h
-- Looking for C++ include parallel_hashmap/btree.h - found
-- Looking for lzma_auto_decoder in /usr/lib64/liblzma.so
-- Looking for lzma_auto_decoder in /usr/lib64/liblzma.so - found
-- Looking for lzma_easy_encoder in /usr/lib64/liblzma.so
-- Looking for lzma_easy_encoder in /usr/lib64/liblzma.so - found
-- Looking for lzma_lzma_preset in /usr/lib64/liblzma.so
-- Looking for lzma_lzma_preset in /usr/lib64/liblzma.so - found
-- Found LibLZMA: /usr/lib64/liblzma.so (found version "5.8.1")
-- Found nlohmann_json: /usr/share/cmake/nlohmann_json/nlohmann_jsonConfig.cmake (found version "3.12.0")
-- Found asio: /usr/include
-- Found OpenSSL: /usr/lib64/libcrypto.so (found suitable version "3.5.4", minimum required is "3.0.0") found components: Crypto SSL
-- Found httplib: /usr/lib64/libcpp-httplib.so.0.26.0 (found version "0.26.0")
-- Found X11: /usr/include
-- Looking for XOpenDisplay in /usr/lib64/libX11.so;/usr/lib64/libXext.so
-- Looking for XOpenDisplay in /usr/lib64/libX11.so;/usr/lib64/libXext.so - found
-- Looking for gethostbyname
-- Looking for gethostbyname - found
-- Looking for connect
-- Looking for connect - found
-- Looking for remove
-- Looking for remove - found
-- Looking for shmat
-- Looking for shmat - found
-- Looking for IceConnectionNumber in ICE
-- Looking for IceConnectionNumber in ICE - found
-- Checking for module 'vorbisfile'
--   Found vorbisfile, version 1.3.7
-- Checking for module 'vorbis'
--   Found vorbis, version 1.3.7
-- Checking for module 'ogg'
--   Found ogg, version 1.3.6
CMake Warning (dev) at /usr/share/cmake/Modules/FindPackageHandleStandardArgs.cmake:430 (message):
  The package name passed to find_package_handle_standard_args() (X11) does
  not match the name of the calling package (OpenGL).  This can lead to
  problems in calling code that expects find_package() result variables
  (e.g., `_FOUND`) to follow a certain pattern.
Call Stack (most recent call first):
  /usr/share/cmake/Modules/FindX11.cmake:684 (find_package_handle_standard_args)
  cmake/FindOpenGL.cmake:128 (INCLUDE)
  src/CMakeLists.txt:256 (find_package)
This warning is for project developers.  Use -Wno-dev to suppress it.

-- Found GLEW: /usr/lib64/libGLEW.so
-- Found LuaJIT: /usr/lib64/libluajit-5.1.so
-- Configuring done (4.8s)
-- Generating done (0.0s)
-- Build files have been written to: /var/tmp/otclient-4.0b3/build
```

The parts that specifically indicate the successful execution of this change, are as follows:
```
-- Checking for module 'vorbisfile'
--   Found vorbisfile, version 1.3.7
-- Checking for module 'vorbis'
--   Found vorbis, version 1.3.7
-- Checking for module 'ogg'
--   Found ogg, version 1.3.6
```

## Checklist

  - [X] My code follows the style guidelines of this project
  - [X] I have performed a self-review of my own code
  - [X] I checked the PR checks reports
  - [ ] I have commented my code, particularly in hard-to-understand areas
  - [ ] I have made corresponding changes to the documentation
  - [X] My changes generate no new warnings (tested only on Linux)
  - [ ] I have added tests that prove my fix is effective or that my feature works
