### PR TITLE
perf: parallelize draw pipeline (FOREGROUND starts collecting without waiting MAP preLoad)

### DIFF
--- a/src/framework/core/graphicalapplication.cpp
+++ b/src/framework/core/graphicalapplication.cpp
@@ -191,9 +191,10 @@ void GraphicalApplication::run()
                 continue;
             }
 
-            bool canDrawMap = false;
-            if (m_drawEvents->canDraw(DrawPoolType::MAP)) {
-                canDrawMap = true;
+            bool canDrawMap = m_drawEvents->canDraw(DrawPoolType::MAP);
+            bool canDrawForeground = !g_drawPool.isDrawing(DrawPoolType::FOREGROUND) && m_drawEvents->canDraw(DrawPoolType::FOREGROUND);
+
+            if (canDrawMap) {
                 for (const auto type : { DrawPoolType::MAP, DrawPoolType::LIGHT, DrawPoolType::FOREGROUND_MAP }) {
                     if (g_drawPool.isDrawing(type)) {
                         canDrawMap = false;
@@ -202,7 +203,8 @@ void GraphicalApplication::run()
                 }
 
                 if (canDrawMap) {
-                    if (!g_drawPool.isDrawing(DrawPoolType::FOREGROUND) && m_drawEvents->canDraw(DrawPoolType::FOREGROUND)) {
+                    if (canDrawForeground) {
+                        canDrawForeground = false;
                         tasks.emplace_back(g_asyncDispatcher.submit_task([] {
                             g_ui.render(DrawPoolType::FOREGROUND);
                         }));
@@ -225,7 +227,7 @@ void GraphicalApplication::run()
                 }
             }
 
-            if (!canDrawMap && m_drawEvents->canDraw(DrawPoolType::FOREGROUND)) {
+            if (!canDrawMap && canDrawForeground) {
                 g_ui.render(DrawPoolType::FOREGROUND);
             }
 

--- a/src/framework/core/graphicalapplication.cpp
+++ b/src/framework/core/graphicalapplication.cpp
@@ -157,6 +157,21 @@ void GraphicalApplication::mainLoop() {
 }
 #endif
 
+bool GraphicalApplication::canDrawMap() const {
+    using enum DrawPoolType;
+
+    if (!m_drawEvents->canDraw(MAP))
+        return false;
+
+    static constexpr std::array<DrawPoolType, 3> types{ MAP, LIGHT, FOREGROUND_MAP };
+
+    for (DrawPoolType type : types) {
+        if (g_drawPool.isDrawing(type))
+            return false;
+    }
+    return true;
+}
+
 void GraphicalApplication::run()
 {
     // run the first poll
@@ -181,19 +196,6 @@ void GraphicalApplication::run()
     // THREAD - POOL & MAP
     const auto& mapThread = g_asyncDispatcher.submit_task([this] {
         BS::multi_future<void> tasks;
-
-        auto canDrawMap = [this] {
-            if (!m_drawEvents->canDraw(DrawPoolType::MAP))
-                return false;
-
-            for (const auto type : { DrawPoolType::MAP, DrawPoolType::LIGHT, DrawPoolType::FOREGROUND_MAP }) {
-                if (g_drawPool.isDrawing(type)) {
-                    return false;
-                }
-            }
-
-            return true;
-        };
 
         g_luaThreadId = g_eventThreadId = stdext::getThreadId();
         while (!m_stopping) {

--- a/src/framework/core/graphicalapplication.cpp
+++ b/src/framework/core/graphicalapplication.cpp
@@ -217,7 +217,8 @@ void GraphicalApplication::run()
 
                 m_drawEvents->preLoad();
 
-                for (const auto type : { DrawPoolType::LIGHT, DrawPoolType::FOREGROUND_MAP }) {
+                static constexpr std::array<DrawPoolType, 2> types{ DrawPoolType::LIGHT, DrawPoolType::FOREGROUND_MAP };
+                for (const auto type : types) {
                     if (m_drawEvents->canDraw(type)) {
                         tasks.emplace_back(g_asyncDispatcher.submit_task([this, type] {
                             m_drawEvents->draw(type);

--- a/src/framework/core/graphicalapplication.h
+++ b/src/framework/core/graphicalapplication.h
@@ -140,6 +140,7 @@ protected:
     void inputEvent(const InputEvent& event);
 
 private:
+    bool canDrawMap() const;
     bool m_onInputEvent{ false };
     bool m_optimize{ true };
     bool m_forceEffectOptimization{ true };

--- a/src/framework/graphics/drawpool.cpp
+++ b/src/framework/graphics/drawpool.cpp
@@ -259,7 +259,7 @@ bool DrawPool::canRepaint()
     if (m_shaderRefreshDelay > 0 && (m_refreshDelay == 0 || m_shaderRefreshDelay < m_refreshDelay))
         refreshDelay = m_shaderRefreshDelay;
 
-    return refreshDelay > 0 && m_refreshTimer.ticksElapsed() >= refreshDelay;
+    return refreshDelay == 0 || m_refreshTimer.ticksElapsed() >= refreshDelay;
 }
 
 void DrawPool::release() {

--- a/src/framework/graphics/drawpoolmanager.h
+++ b/src/framework/graphics/drawpoolmanager.h
@@ -124,13 +124,9 @@ private:
     void drawPool(DrawPoolType type);
     void drawObjects(DrawPool* pool);
 
-    inline bool isDrawing() const {
-        for (auto pool : m_pools) {
-            if (pool->isEnabled() && pool->shouldRepaint())
-                return true;
-        }
-
-        return false;
+    inline bool isDrawing(const DrawPoolType type) const {
+        auto pool = get(type);
+        return pool->isEnabled() && pool->shouldRepaint();
     }
 
     std::array<DrawPool*, static_cast<uint8_t>(DrawPoolType::LAST)> m_pools{};


### PR DESCRIPTION
FOREGROUND now starts collecting/preparing data earlier, without being blocked by the MAP preLoad(), enabling better frame-level parallelism.