### PR TITLE
fix(vbot):  item list scroll to bottom on new entry

### DIFF
--- a/mods/game_bot/functions/ui_elements.lua
+++ b/mods/game_bot/functions/ui_elements.lua
@@ -25,6 +25,13 @@ UI.Container = function(callback, unique, parent, widget)
 
   local oldItems = {}
 
+  local scrollToBottom = function()
+    local scrollbar = widget.scroll
+    if scrollbar and scrollbar.setValue and scrollbar.getMaximum then
+      scrollbar:setValue(scrollbar:getMaximum())
+    end
+  end
+
   local updateItems = function()
     local items = widget:getItems()
 
@@ -71,6 +78,7 @@ UI.Container = function(callback, unique, parent, widget)
     for i, child in ipairs(widget.items:getChildren()) do
       child.onItemChange = updateItems
     end
+    scrollToBottom()
   end
 
   widget.getItems = function()


### PR DESCRIPTION
# Description

previously when adding a new item to a large list, the list would practically scroll to the top each time. for very long lists with a lot of stuff to add, this becomes increasingly annoying and time-consuming for each new entry, to scroll back to the bottom to add a new one

for small lists, it makes no difference, for large lists, this makes it easier to add new entries.


## Behavior



### **Actual**

Do this and that doesn't happens

### **Expected**

Do this and that happens

## Fixes

\# (issue)

## Type of change

Please delete options that are not relevant.

  - [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested

adding items to large lists:
<img width="184" height="147" alt="image" src="https://github.com/user-attachments/assets/ec7a4644-994e-47be-ab02-ba4cff6b6202" />


**Test Configuration**:

  - Server Version: yurots something, protocol 760
  - Client: git main build
  - Operating System: windows

## Checklist

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [ ] I checked the PR checks reports
  - [ ] I have commented my code, particularly in hard-to-understand areas
  - [ ] I have made corresponding changes to the documentation
  - [x] My changes generate no new warnings
  - [ ] I have added tests that prove my fix is effective or that my feature works
