### PR TITLE
fix(vbot): Expose Directions to bot sandbox

### DIFF
--- a/mods/game_bot/executor.lua
+++ b/mods/game_bot/executor.lua
@@ -151,6 +151,7 @@ function executeBot(config, storage, tabs, msgCallback, saveConfigCallback, relo
   context.HTTP = HTTP
   context.OutputMessage = OutputMessage
   context.modules = modules
+  context.Directions = Directions
 
   -- log functions
   context.info = function(text) return msgCallback("info", tostring(text)) end


### PR DESCRIPTION
Allow doing
```lua
g_game.walk(Directions.South)
```
instead of
```lua
g_game.walk(2)
```
in cavebot waypoint Functions.

Was in a situation where I needed the cavebot to walk exactly 1 sqm south, and the cavebot's built-in "Go To" command is not reliable for that, when you need precision walking.

Furthermore, the cavebot's poscheck: was not reliable either, PR to make cavebot's poscheck: reliable: https://github.com/mehah/otclient/pull/1532