### PR TITLE
fix(vbot): typo in method name: 'hasCreature' to 'hasCreatures'

### DIFF
--- a/mods/game_bot/default_configs/vBot_4.8/cavebot/actions.lua
+++ b/mods/game_bot/default_configs/vBot_4.8/cavebot/actions.lua
@@ -45,7 +45,7 @@ onTextMessage(function(mode, text)
   local tiles = getNearTiles(pos())
 
   for i, tile in ipairs(tiles) do
-    if not tile:hasCreature() and tile:isWalkable() and #tile:getItems() > 9 then
+    if not tile:hasCreatures() and tile:isWalkable() and #tile:getItems() > 9 then
       local topThing = tile:getTopThing()
       if not isInPz() then
         return useWith(3197, tile:getTopThing()) -- disintegrate
@@ -359,7 +359,7 @@ CaveBot.registerAction("goto", "green", function(value, retries, prev)
 
       local tile = g_map.getTile(nextPos)
       if tile then
-          if tile:hasCreature() then
+          if tile:hasCreatures() then
               local creature = tile:getCreatures()[1]
               local hppc = creature:getHealthPercent()
               if creature:isMonster() and (hppc and hppc > 0) and (oldTibia or creature:getType() < 3) then

--- a/mods/game_bot/default_configs/vBot_4.8/cavebot/clear_tile.lua
+++ b/mods/game_bot/default_configs/vBot_4.8/cavebot/clear_tile.lua
@@ -39,7 +39,7 @@ CaveBot.Extensions.ClearTile.setup = function()
     local tPos = tile:getPosition()
 
     -- no items on tile and walkability means we are done
-    if tile:isWalkable() and tile:getTopUseThing():isNotMoveable() and not tile:hasCreature() and not doors then
+    if tile:isWalkable() and tile:getTopUseThing():isNotMoveable() and not tile:hasCreatures() and not doors then
       if stand then
         if not CaveBot.MatchPosition(tPos, 0) then
           CaveBot.GoTo(tPos, 0)
@@ -60,7 +60,7 @@ CaveBot.Extensions.ClearTile.setup = function()
     end
 
     -- monster
-    if tile:hasCreature() then
+    if tile:hasCreatures() then
       local c = tile:getCreatures()[1]
       if c:isMonster() then
         attack(c)
@@ -81,7 +81,7 @@ CaveBot.Extensions.ClearTile.setup = function()
     -- player
 
       -- push creature
-      if tile:hasCreature() then
+      if tile:hasCreatures() then
         local c = tile:getCreatures()[1]
         if c and c:isPlayer() then
 

--- a/mods/game_bot/default_configs/vBot_4.8/cavebot/stand_lure.lua
+++ b/mods/game_bot/default_configs/vBot_4.8/cavebot/stand_lure.lua
@@ -104,7 +104,7 @@ CaveBot.Extensions.StandLure.setup = function()
 
                 local tile = g_map.getTile(nextPos)
                 if tile then
-                    if tile:hasCreature() then
+                    if tile:hasCreatures() then
                         local creature = tile:getCreatures()[1]
                         local hppc = creature:getHealthPercent()
                         if creature:isMonster() and (hppc and hppc > 0) and (oldTibia or creature:getType() < 3) then

--- a/mods/game_bot/default_configs/vBot_4.8/targetbot/creature_attack.lua
+++ b/mods/game_bot/default_configs/vBot_4.8/targetbot/creature_attack.lua
@@ -11,7 +11,7 @@ function getWalkableTilesCount(position)
   local count = 0
 
   for i, tile in pairs(getNearTiles(position)) do
-      if tile:isWalkable() or tile:hasCreature() then
+      if tile:isWalkable() or tile:hasCreatures() then
           count = count + 1
       end
   end
@@ -29,7 +29,7 @@ function rePosition(minTiles)
 
   if playerTilesCount > minTiles then return end
   for i, tile in ipairs(tiles) do
-      tilesTable[tile] = not tile:hasCreature() and tile:isWalkable() and getWalkableTilesCount(tile:getPosition()) or nil
+      tilesTable[tile] = not tile:hasCreatures() and tile:isWalkable() and getWalkableTilesCount(tile:getPosition()) or nil
   end
 
   local best = 0

--- a/mods/game_bot/default_configs/vBot_4.8/vBot/new_cavebot_lib.lua
+++ b/mods/game_bot/default_configs/vBot_4.8/vBot/new_cavebot_lib.lua
@@ -287,7 +287,7 @@ function CaveBot.ReachDepot()
                           lockerTilePos.x = lockerTilePos.x + LOCKER_ACCESSTILE_MODIFIERS[item:getId()][1]
                           lockerTilePos.y = lockerTilePos.y + LOCKER_ACCESSTILE_MODIFIERS[item:getId()][2]
                     local lockerTile = g_map.getTile(lockerTilePos)
-                    if not lockerTile:hasCreature() then
+                    if not lockerTile:hasCreatures() then
                         if findPath(pos(), tPos, 20, {ignoreNonPathable = false, precision = 1, ignoreCreatures = true}) then
                             local distance = getDistanceBetween(tPos, pPos)
                             table.insert(candidates, {pos=tPos, dist=distance})

--- a/mods/game_bot/default_configs/vBot_4.8/vBot/pushmax.lua
+++ b/mods/game_bot/default_configs/vBot_4.8/vBot/pushmax.lua
@@ -205,7 +205,7 @@ macro(50, function()
       return
     end
 
-    if not cleanTile:hasCreature() then return end
+    if not cleanTile:hasCreatures() then return end
     local tiles = getNearTiles(tilePos)
     local destTile
     local forbidden = {}
@@ -220,7 +220,7 @@ macro(50, function()
     for i, tile in pairs(tiles) do
       local minimapColor = g_map.getMinimapColor(tile:getPosition())
       local stairs = (minimapColor >= 210 and minimapColor <= 213)
-      if tile:isWalkable() and not isNotOk(fieldTable, tile) and not tile:hasCreature() and not stairs then
+      if tile:isWalkable() and not isNotOk(fieldTable, tile) and not tile:hasCreatures() and not stairs then
         local tooClose = false
         if #forbidden ~= 0 then
           for i=1,#forbidden do


### PR DESCRIPTION
# Description

> ERROR: command failed: :1: attempt to call method 'hasCreature' (a nil value)



vbot 4.8 has multiple calls to the hasCreature function, which exists in v8. However, in otcr it is called hasCreature**S**.
This change only affects vbot.

## Type of change

Please delete options that are not relevant.

  - [x] Bug fix (non-breaking change which fixes an issue)
