### PR TITLE
fix: cyclopedia map

### DIFF
--- a/modules/game_cyclopedia/tab/map/map.lua
+++ b/modules/game_cyclopedia/tab/map/map.lua
@@ -2,6 +2,7 @@ local UI = nil
 local virtualFloor = 7
 
 function showMap()
+    g_minimap.saveOtmm('/minimap.otmm')
     UI = g_ui.loadUI("map", contentContainer)
     UI:show()
     controllerCyclopedia:registerEvents(LocalPlayer, {

--- a/modules/game_minimap/minimap.lua
+++ b/modules/game_minimap/minimap.lua
@@ -159,6 +159,14 @@ function zoomOut()
     mapController.ui.minimapBorder.minimap:zoomOut()
 end
 
+function openCyclopediaMap()
+    if g_game.getClientVersion() >= 1310 then
+        modules.game_cyclopedia.toggle('map')
+    else
+        return fullscreen()
+    end
+end
+
 function fullscreen()
     local minimapWidget = mapController.ui.minimapBorder.minimap
     if not minimapWidget then

--- a/modules/game_minimap/minimap.otui
+++ b/modules/game_minimap/minimap.otui
@@ -11,7 +11,7 @@ PhantomMiniWindow
     anchors.left: parent.left
     margin-top: 5
     margin-left: 8
-    size: 108 111
+    size: 115 111
     image-source: /images/ui/1pixel_down_frame
 
     Minimap
@@ -75,7 +75,7 @@ PhantomMiniWindow
     anchors.bottom: minimapBorder.bottom
     margin-right: 4
     size: 20 20
-    @onClick: fullscreen()
+    @onClick: openCyclopediaMap()
 
     $hover !disabled:
       image-clip: 0 0 20 20


### PR DESCRIPTION
# Description

This change makes the minimap open directly from the encyclopedia when clicking the full view button and corrects the loss of player progress when opening the map from the cyclopedia.

## Behavior
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/7a75e5c4-10dc-4f14-af50-0ed5865cfc06" />

### **Current**

Currently, clicking "full view" opens the minimap from the encyclopedia.

### **Expected**

Now, clicking "full view" opens the minimap from the encyclopedia.
<img width="1566" height="972" alt="image" src="https://github.com/user-attachments/assets/a4f93324-6451-4ad8-a9be-ce7818181637" />

## Change Type

- [ x] Bug fix (non-disruptive change that corrects a problem)

- [ x] New feature (non-disruptive change that adds functionality)

## How this was tested

When opening the minimap from the encyclopedia, the current minimap was being replaced by the already saved map, overwriting all player progress. This PR fixes this

Credits: Sherrat, for the button function.

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I performed a self-assessment of my code
- [ ] I checked the PR verification reports
- [ ] I commented my code, especially in areas that are difficult to understand
- [ ] I made the corresponding changes in the documentation
- [ ] My changes do not generate new warnings
- [ ] I added tests that prove the effectiveness of my fix or the functionality of my feature