### PR TITLE
fix: datdump vulnerability

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -26,7 +26,9 @@
 #include "framework/core/resourcemanager.h"
 #include "framework/luaengine/luainterface.h"
 #include "framework/platform/platform.h"
+#ifdef FRAMEWORK_EDITOR
 #include "tools/datdump.h"
+#endif
 
 #ifndef ANDROID
 #if ENABLE_DISCORD_RPC == 1
@@ -60,12 +62,11 @@ void printHelp(const std::string& executableName)
     std::cout << "Usage: " << executableName << " [options]\n\n"
                  "General options:\n"
                  "  --help, -h, /?              Show this help message and exit\n"
-                 "  --encrypt <password>        Encrypt assets (requires builder build)\n\n"
+                 "  --encrypt <password>        Encrypt assets (requires ENABLE_ENCRYPTION == 1 && ENABLE_ENCRYPTION_BUILDER == 1 build)\n\n"
                  "DAT debugging:\n"
-                 "  --dump-dat-to-json=<path>   Dump the specified Tibia DAT file as JSON\n"
-                 "    --dump-dat-output=<path>  Write JSON to file instead of stdout\n"
-                 "    --dump-dat-client-version=<ver>  Decode flags using that client version\n"
-                 "    --dump-dat-compact        Emit compact (single-line) JSON\n";
+                 "  --dump-dat-to-json=<path|ver> Dump the specified Tibia DAT file or version as JSON (requires FRAMEWORK_EDITOR build)\n"
+                 "    --dump-dat-output=<path>    Write JSON to file instead of stdout\n"
+                 "    --dump-dat-compact          Emit compact (single-line) JSON\n";
 }
 
 } // namespace
@@ -76,7 +77,6 @@ void printHelp(const std::string& executableName)
 
         // process args encoding
         g_platform.init(args);
-
 
         // initialize resources
 #ifdef ANDROID
@@ -112,9 +112,11 @@ void printHelp(const std::string& executableName)
             return 0;
         }
 
+#ifdef FRAMEWORK_EDITOR
         if (const auto dumpRequest = datdump::parseRequest(args); dumpRequest) {
             return datdump::run(*dumpRequest) ? 0 : 1;
         }
+#endif
 
         // initialize application framework and otclient
         const auto drawEvents = ApplicationDrawEventsPtr(&g_client, [](ApplicationDrawEvents*) {});

--- a/src/tools/datdump.cpp
+++ b/src/tools/datdump.cpp
@@ -91,22 +91,70 @@ json thingTypeToJson(const ThingTypePtr& type, const ThingCategory category, con
         { "z", type->getNumPatternZ() },
     };
     entry["animationPhases"] = type->getAnimationPhases();
-    entry["groundSpeed"] = type->getGroundSpeed();
-    entry["elevation"] = type->getElevation();
+    entry["displacement"] = type->hasDisplacement()
+            ? json{{ "x", type->getDisplacementX() }, { "y", type->getDisplacementY() }}
+            : json("none");
+    if (category == ThingCategoryItem) {
+        entry["groundSpeed"] = type->hasAttr(ThingAttrGround) ? json(type->getGroundSpeed()) : json("none");
+        entry["elevation"] = type->hasAttr(ThingAttrElevation) ? json(type->getElevation()) : json("none");
 
-    auto& flags = entry["flags"];
-    flags["floorChange"] = type->hasAttr(ThingAttrFloorChange);
-    flags["ground"] = type->isGround();
-    flags["groundBorder"] = type->isGroundBorder();
-    flags["onTop"] = type->isOnTop();
-    flags["onBottom"] = type->isOnBottom();
-    flags["fullGround"] = type->isFullGround();
-    flags["notWalkable"] = type->isNotWalkable();
-    flags["notPathable"] = type->isNotPathable();
-    flags["blockProjectile"] = type->blockProjectile();
-    flags["hasElevation"] = type->hasAttr(ThingAttrElevation);
-    flags["hasDisplacement"] = type->hasAttr(ThingAttrDisplacement);
-    flags["hasLight"] = type->hasAttr(ThingAttrLight);
+
+        entry["light"] = type->hasLight()
+            ? json{{ "intensity", type->getLight().intensity }, { "color", type->getLight().color } }
+            : json("none");
+        entry["minimapColor"] = type->hasMiniMapColor() ? json(type->getMinimapColor()) : json("none");
+        entry["lensHelp"] = type->hasLensHelp() ? json(type->getLensHelp()) : json("none");
+
+        auto setFlag = [&](const std::string& key, const ThingAttr attr, const bool value) {
+            entry["flags"][key] = type->hasAttr(attr) ? json(value) : json("none");
+        };
+
+        setFlag("floorChange", ThingAttrFloorChange, type->hasAttr(ThingAttrFloorChange));
+        setFlag("ground", ThingAttrGround, type->isGround());
+        setFlag("groundBorder", ThingAttrGroundBorder, type->isGroundBorder());
+        setFlag("onTop", ThingAttrOnTop, type->isOnTop());
+        setFlag("onBottom", ThingAttrOnBottom, type->isOnBottom());
+        setFlag("fullGround", ThingAttrFullGround, type->isFullGround());
+        setFlag("notWalkable", ThingAttrNotWalkable, type->isNotWalkable());
+        setFlag("notPathable", ThingAttrNotPathable, type->isNotPathable());
+        setFlag("blockProjectile", ThingAttrBlockProjectile, type->blockProjectile());
+        setFlag("container", ThingAttrContainer, type->isContainer());
+        setFlag("stackable", ThingAttrStackable, type->isStackable());
+        setFlag("forceUse", ThingAttrForceUse, type->isForceUse());
+        setFlag("multiUse", ThingAttrMultiUse, type->isMultiUse());
+        setFlag("writable", ThingAttrWritable, type->isWritable());
+        setFlag("writableOnce", ThingAttrWritableOnce, type->isWritableOnce());
+        setFlag("chargeable", ThingAttrChargeable, type->isChargeable());
+        setFlag("fluidContainer", ThingAttrFluidContainer, type->isFluidContainer());
+        setFlag("splash", ThingAttrSplash, type->isSplash());
+        setFlag("hasElevation", ThingAttrElevation, type->hasAttr(ThingAttrElevation));
+        setFlag("hasDisplacement", ThingAttrDisplacement, type->hasAttr(ThingAttrDisplacement));
+        setFlag("hasLight", ThingAttrLight, type->hasAttr(ThingAttrLight));
+        setFlag("notMoveable", ThingAttrNotMoveable, type->isNotMoveable());
+        setFlag("pickupable", ThingAttrPickupable, type->isPickupable());
+        setFlag("hangable", ThingAttrHangable, type->isHangable());
+        setFlag("hookSouth", ThingAttrHookSouth, type->isHookSouth());
+        setFlag("hookEast", ThingAttrHookEast, type->isHookEast());
+        setFlag("rotateable", ThingAttrRotateable, type->isRotateable());
+        setFlag("dontHide", ThingAttrDontHide, type->isDontHide());
+        setFlag("translucent", ThingAttrTranslucent, type->isTranslucent());
+        setFlag("lyingCorpse", ThingAttrLyingCorpse, type->isLyingCorpse());
+        setFlag("animateAlways", ThingAttrAnimateAlways, type->isAnimateAlways());
+        setFlag("ignoreLook", ThingAttrLook, type->isIgnoreLook());
+        setFlag("cloth", ThingAttrCloth, type->isCloth());
+        setFlag("market", ThingAttrMarket, type->isMarketable());
+        setFlag("usable", ThingAttrUsable, type->isUsable());
+        setFlag("wrapable", ThingAttrWrapable, type->isWrapable());
+        setFlag("unwrapable", ThingAttrUnwrapable, type->isUnwrapable());
+        setFlag("wearOut", ThingAttrWearOut, type->hasWearOut());
+        setFlag("clockExpire", ThingAttrClockExpire, type->hasClockExpire());
+        setFlag("expire", ThingAttrExpire, type->hasExpire());
+        setFlag("expireStop", ThingAttrExpireStop, type->hasExpireStop());
+        setFlag("podium", ThingAttrPodium, type->isPodium());
+        setFlag("topEffect", ThingAttrTopEffect, type->isTopEffect());
+        setFlag("defaultAction", ThingAttrDefaultAction, type->hasAction());
+        setFlag("decoKit", ThingAttrDecoKit, type->isDecoKit());
+    }
 
     return entry;
 }
@@ -121,9 +169,10 @@ std::optional<Request> parseRequest(std::vector<std::string>& args)
 
         Request request;
         if (auto datValue = readFlagValue(args, i, "--dump-dat-to-json"); datValue) {
-            request.datPath = *datValue;
+                request.datPath = "data/things/" + *datValue + "/Tibia.dat";
+                request.clientVersion = std::stoi(*datValue);
         } else {
-            throw std::runtime_error("--dump-dat-to-json requires an argument (e.g. --dump-dat-to-json=data/Tibia.dat)");
+            throw std::runtime_error("--dump-dat-to-json requires an argument (e.g. --dump-dat-to-json=version)");
         }
 
         args.erase(args.begin() + static_cast<long>(i));
@@ -134,19 +183,6 @@ std::optional<Request> parseRequest(std::vector<std::string>& args)
                 args.erase(args.begin() + static_cast<long>(j));
                 continue;
             }
-
-            if (auto value = readFlagValue(args, j, "--dump-dat-client-version"); value) {
-                try {
-                    request.clientVersion = std::stoi(*value);
-                } catch (const std::exception&) {
-                    std::throw_with_nested(
-                        std::invalid_argument("invalid --dump-dat-client-version value")
-                    );
-                }
-                args.erase(args.begin() + static_cast<long>(j));
-                continue;
-            }
-
             if (args[j] == "--dump-dat-compact") {
                 request.compactOutput = true;
                 args.erase(args.begin() + static_cast<long>(j));
@@ -170,7 +206,6 @@ bool run(const Request& request)
 
     g_lua.init();
     g_things.init();
-
     if (request.clientVersion > 0)
         g_game.setClientVersion(static_cast<uint16_t>(request.clientVersion));
 

--- a/src/tools/datdump.cpp
+++ b/src/tools/datdump.cpp
@@ -174,6 +174,14 @@ bool run(const Request& request)
     if (request.clientVersion > 0)
         g_game.setClientVersion(static_cast<uint16_t>(request.clientVersion));
 
+    const int version = request.clientVersion;
+    if (version >= 960)
+        g_game.enableFeature(Otc::GameSpritesU32);
+    if (version >= 1050)
+        g_game.enableFeature(Otc::GameEnhancedAnimations);
+    if (version >= 1057)
+        g_game.enableFeature(Otc::GameIdleAnimations);
+
     if (!g_things.loadDat(request.datPath)) {
         throw std::runtime_error("unable to load DAT file: " + request.datPath);
     }


### PR DESCRIPTION

## Description




*   **Security hardening with `FRAMEWORK_EDITOR`**: 
    The `datdump` functionality is now guarded by the `FRAMEWORK_EDITOR` flag. This prevents unauthorized extraction of `.dat` information in production or hosted server environments where data protection is critical. Only builds explicitly targeting editor tools will have access to these debugging features.

*   **Expanded Client Version Support**:
    Previously, the tool was largely limited to older clients (e.g., 7.60). I have added logic to automatically enable necessary game features for newer clients:
    *   `GameSpritesU32` for versions >= 9.60
    *   `GameEnhancedAnimations` for versions >= 10.50
    *   `GameIdleAnimations` for versions >= 10.57
    
    This ensures correct parsing and dumping for modern Tibia versions

*   **Enhanced JSON Output**:
    Added missing DAT attributes to the JSON export, providing a more complete representation of the asset data.

*   **CLI Improvements**:
    *   Simplified usage: You can now pass just the version number (e.g., `--dump-dat-to-json=760`), and the tool will automatically resolve the standard path [data/things/760/Tibia.dat](cci:7://file:///d:/github/otclient.readme/data/things/760/Tibia.dat:0:0-0:0).
    *   Updated the Help message to clearly reflect these requirements and new options.

## Usage Example
```bash
# Old way
otclient --dump-dat-to-json=data/things/1098/Tibia.dat --dump-dat-client-version=1098 > pdumpDat.json

# New way (auto-resolves path and version)
otclient --dump-dat-to-json=1098 > pdumpDat.json
```

<img width="407" height="211" alt="image" src="https://github.com/user-attachments/assets/354baad6-da34-4289-8549-d819c2ac4033" />
<img width="407" height="618" alt="image" src="https://github.com/user-attachments/assets/dc90c9a5-0f4e-4fee-9664-a12c8a5a992b" />

<img width="407" height="496" alt="image" src="https://github.com/user-attachments/assets/76639b45-4731-442c-860e-7fa54745e186" />
<img width="407" height="496" alt="image" src="https://github.com/user-attachments/assets/bf311379-1fb2-4bc3-ae3b-7829de2cf5a2" />
<img width="407" height="496" alt="image" src="https://github.com/user-attachments/assets/09090dfd-7403-4379-944c-973c2cbc6ba5" />


test in 7.6 ,8.6 , 10.98