### PR TITLE
fix(#1460): "Failed to fetch sprite id 0" 

### DIFF
--- a/src/client/thingtype.cpp
+++ b/src/client/thingtype.cpp
@@ -770,25 +770,23 @@ void ThingType::loadTexture(const int animationPhase)
                                 return;
 
                             if (!spriteImage) {
-                                if (spriteId != 0) {
-                                    g_logger.error("Failed to fetch sprite id {} for thing {} ({}, {}), layer {}, pattern {}x{}x{}, frame {}", spriteId, m_name, m_id, categoryName(m_category), l, x, y, z, animationPhase);
-                                    return;
-                                }
-                            } else {
-                                // verifies that the first block in the lower right corner is transparent.
-                                if (spriteImage->hasTransparentPixel()) {
-                                    fullImage->setTransparentPixel(true);
-                                }
-
-                                if (spriteMask) {
-                                    spriteImage->overwriteMask(maskColors[(l - 1)]);
-                                }
-
-                                auto spriteSize = spriteImage->getSize() / g_gameConfig.getSpriteSize();
-
-                                const Point& spritePos = Point(m_size.width() - spriteSize.width(), m_size.height() - spriteSize.height()) * g_gameConfig.getSpriteSize();
-                                fullImage->blit(framePos + spritePos, spriteImage);
+                                g_logger.error("Failed to fetch sprite id {} for thing {} ({}, {}), layer {}, pattern {}x{}x{}, frame {}", spriteId, m_name, m_id, categoryName(m_category), l, x, y, z, animationPhase);
+                                return;
                             }
+
+                            // verifies that the first block in the lower right corner is transparent.
+                            if (!spriteImage || spriteImage->hasTransparentPixel()) {
+                                fullImage->setTransparentPixel(true);
+                            }
+
+                            if (spriteMask) {
+                                spriteImage->overwriteMask(maskColors[(l - 1)]);
+                            }
+
+                            auto spriteSize = spriteImage->getSize() / g_gameConfig.getSpriteSize();
+
+                            const Point& spritePos = Point(m_size.width() - spriteSize.width(), m_size.height() - spriteSize.height()) * g_gameConfig.getSpriteSize();
+                            fullImage->blit(framePos + spritePos, spriteImage);
                         } else {
                             for (int h = 0; h < m_size.height(); ++h) {
                                 for (int w = 0; w < m_size.width(); ++w) {
@@ -801,23 +799,21 @@ void ThingType::loadTexture(const int animationPhase)
                                         return;
 
                                     if (!spriteImage) {
-                                        if (spriteId != 0) {
-                                            g_logger.error("Failed to fetch sprite id {} for thing {} ({}, {}), layer {}, pattern {}x{}x{}, frame {}, offset {}x{}", spriteId, m_name, m_id, categoryName(m_category), l, x, y, z, framePos, w, h);
-                                            return;
-                                        }
-                                    } else {
-                                        // verifies that the first block in the lower right corner is transparent.
-                                        if (h == 0 && w == 0 && spriteImage->hasTransparentPixel()) {
-                                            fullImage->setTransparentPixel(true);
-                                        }
-
-                                        if (spriteMask) {
-                                            spriteImage->overwriteMask(maskColors[(l - 1)]);
-                                        }
-
-                                        const Point& spritePos = Point(m_size.width() - w - 1, m_size.height() - h - 1) * g_gameConfig.getSpriteSize();
-                                        fullImage->blit(framePos + spritePos, spriteImage);
+                                        g_logger.error("Failed to fetch sprite id {} for thing {} ({}, {}), layer {}, pattern {}x{}x{}, frame {}, offset {}x{}", spriteId, m_name, m_id, categoryName(m_category), l, x, y, z, framePos, w, h);
+                                        return;
                                     }
+
+                                    // verifies that the first block in the lower right corner is transparent.
+                                    if (h == 0 && w == 0 && (!spriteImage || spriteImage->hasTransparentPixel())) {
+                                        fullImage->setTransparentPixel(true);
+                                    }
+
+                                    if (spriteMask) {
+                                        spriteImage->overwriteMask(maskColors[(l - 1)]);
+                                    }
+
+                                    const Point& spritePos = Point(m_size.width() - w - 1, m_size.height() - h - 1) * g_gameConfig.getSpriteSize();
+                                    fullImage->blit(framePos + spritePos, spriteImage);
                                 }
                             }
                         }

--- a/src/client/thingtype.cpp
+++ b/src/client/thingtype.cpp
@@ -792,6 +792,10 @@ void ThingType::loadTexture(const int animationPhase)
                                 for (int w = 0; w < m_size.width(); ++w) {
                                     const uint32_t spriteIndex = getSpriteIndex(w, h, spriteMask ? 1 : l, x, y, z, animationPhase);
                                     auto spriteId = m_spritesIndex[spriteIndex];
+
+                                    if (spriteId == 0)
+                                        continue;
+
                                     bool isLoading = false;
                                     const auto& spriteImage = g_sprites.getSpriteImage(spriteId, isLoading);
 


### PR DESCRIPTION
# Do not approve until @Nottinghster tests it in their environment.

This change only affects the .dat and .spr systems.

## Description

This PR fixes an issue where the client logged "Failed to fetch sprite id 0" errors when loading textures for multi-tile things (items/creatures) that have empty spaces (holes).

When a thing is multi-tile but irregular (e.g., L-shaped), the empty slots in its bounding box are padded with `spriteId = 0`. The previous code attempted to fetch this invalid sprite ID 0, causing the error. This fix explicitly skips sprite ID 0 during the texture loading loop.

I reversed my commits  that wasn't working.
<img width="430" height="56" alt="image" src="https://github.com/user-attachments/assets/5a0ed85e-c3a9-405a-aedd-306a0b19ac21" />

## Behavior

### **Actual**
The client logs `ERROR: Failed to fetch sprite id 0` when encountering multi-tile items with empty slots in their pattern.

### **Expected**
The client correctly skips empty slots (ID 0) and reconstructs the multi-tile texture without errors.

## Fixes
#1460

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested

- [x] Verified with multi-tile items that previously caused the "fetch sprite id 0" error.
- [x] Confirmed that the error log no longer appears and the items render correctly.

**Test Configuration**:
- Operating System: Windows