### PR TITLE
fix: skip blank sprites silently to prevent console spam

### DIFF
--- a/src/client/thingtype.cpp
+++ b/src/client/thingtype.cpp
@@ -792,10 +792,6 @@ void ThingType::loadTexture(const int animationPhase)
                                 for (int w = 0; w < m_size.width(); ++w) {
                                     const uint32_t spriteIndex = getSpriteIndex(w, h, spriteMask ? 1 : l, x, y, z, animationPhase);
                                     auto spriteId = m_spritesIndex[spriteIndex];
-
-                                    if (spriteId == 0)
-                                        continue;
-
                                     bool isLoading = false;
                                     const auto& spriteImage = g_sprites.getSpriteImage(spriteId, isLoading);
 
@@ -803,8 +799,8 @@ void ThingType::loadTexture(const int animationPhase)
                                         return;
 
                                     if (!spriteImage) {
-                                        g_logger.error("Failed to fetch sprite id {} for thing {} ({}, {}), layer {}, pattern {}x{}x{}, frame {}, offset {}x{}", spriteId, m_name, m_id, categoryName(m_category), l, x, y, z, framePos, w, h);
-                                        return;
+                                        // Skip blank sprites silently (clients converted with Assets Editor have blank sprites with non-zero IDs)
+                                        continue;
                                     }
 
                                     // verifies that the first block in the lower right corner is transparent.


### PR DESCRIPTION
Skip blank sprites silently instead of logging errors when loading textures.

Clients converted with the Assets Editor may have blank sprites with non-zero IDs.
Previously, these would cause error logs and interrupt texture loading. Now, blank
sprites are silently skipped using continue, allowing valid sprites to load properly
and preventing console spam.

This change applies to the non-protobuf sprite loading path, where sprites are
loaded per-pixel position. Blank sprites (spriteId != 0 but spriteImage == nullptr)
are now ignored silently, similar to how spriteId == 0 is already handled.

<img width="1920" height="1032" alt="image" src="https://github.com/user-attachments/assets/0de0987d-3fd6-4805-997a-6203be7421fe" />
