### PR TITLE
rollback: onGameStart without addEvent (fix:#1558)

### DIFF
--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -186,7 +186,7 @@ void Game::processGameStart()
         }
     }, 1000);
 
-    g_dispatcher.addEvent([] { g_lua.callGlobalField("g_game", "onGameStart"); });
+    g_lua.callGlobalField("g_game", "onGameStart");
 }
 
 void Game::processGameEnd()


### PR DESCRIPTION
# Description

# Reason for the change:

The original issue was a visual bug that appeared briefly (less than 5 milliseconds) when activating Atlas in UI(`FOREGROUND`), occurring less than 10% of the time. To identify it, i had to reproduce the issue in slow motion gif.

![gifardo](https://github.com/user-attachments/assets/029b52ad-804c-49e5-b369-744eadbfba7d)

# Initial solution:

An addEvent was implemented to mitigate the visual bug, which effectively solved the problem in most cases. However, this solution has caused precedence conflicts with other "`connect(XXXX, {lua call]`" in modules.

# Proposed action:

Since the addEvent has introduced additional issues, **I prefer to accept the visual bug (lasting 5 milliseconds, and probability of occurrence less than 10%**) rather than cause multiple errors in the modules due to the delay in onGameStart. Therefore, I propose a rollback and to look for a better solution in the long term.

# Current status in main repo 01/09/26 0752f9dffb3b929b9c28f2453f7005e70c26708c

It's worth noting that, since other changes were made to the OTC, the visual bug has not been observed in the last 10 logins, suggesting that the issue may have been partially mitigated by other adjustments.


# solve: 
- [x] https://github.com/mehah/otclient/pull/1514
- [x] https://github.com/mehah/otclient/issues/1558


