### PR TITLE
fix: game_textmessage Relationship 1:1 with Tibia Qt and Oldprotocol

### DIFF
--- a/modules/game_textmessage/textmessage.lua
+++ b/modules/game_textmessage/textmessage.lua
@@ -197,6 +197,17 @@ MessageTypes = {
 messagesPanel = nil
 
 function init()
+    if g_game.getClientVersion() >= 1300 then
+        MessageTypes[MessageModes.Loot] = MessageSettings.loot
+        MessageTypes[MessageModes.ValuableLoot] = MessageSettings.valuableLoot
+        MessageTypes[MessageModes.Guild] = MessageSettings.statusOwn
+        MessageTypes[MessageModes.Party] = MessageSettings.statusOwn
+    else
+        MessageTypes[MessageModes.Loot] = MessageSettings.centerGreen
+        MessageTypes[MessageModes.ValuableLoot] = MessageSettings.centerGreen
+        MessageTypes[MessageModes.Guild] = MessageSettings.centerGreen
+        MessageTypes[MessageModes.Party] = MessageSettings.centerGreen
+    end
     for messageMode, _ in pairs(MessageTypes) do
         registerMessageMode(messageMode, displayMessage)
     end

--- a/modules/game_textmessage/textmessage.lua
+++ b/modules/game_textmessage/textmessage.lua
@@ -73,23 +73,28 @@ MessageSettings = {
     },
     private = {
         color = TextColors.lightblue,
+        consoleTab = 'Local Chat',
         screenTarget = 'privateLabel'
     },
     privateRed = {
         color = TextColors.red,
+        consoleTab = 'Local Chat',
         private = true
     },
     privatePlayerToPlayer = {
         color = TextColors.blue,
+        consoleTab = 'Local Chat',
         private = true
     },
     privatePlayerToNpc = {
         color = TextColors.blue,
+        consoleTab = 'Local Chat',
         private = true,
         npcChat = true
     },
     privateNpcToPlayer = {
         color = TextColors.lightblue,
+        consoleTab = 'Local Chat',
         private = true,
         npcChat = true
     },

--- a/modules/game_textmessage/textmessage.lua
+++ b/modules/game_textmessage/textmessage.lua
@@ -1,5 +1,9 @@
 MessageSettings = {
     none = {},
+    consoleYellow = {
+        color = TextColors.yellow,
+        consoleTab = 'Local Chat'
+    },
     consoleRed = {
         color = TextColors.red,
         consoleTab = 'Local Chat'
@@ -23,6 +27,12 @@ MessageSettings = {
         screenTarget = 'highCenterLabel',
         consoleOption = 'showInfoMessagesInConsole'
     },
+    centerHKGreen = {
+        color = TextColors.green,
+        consoleTab = 'Server Log',
+        screenTarget = 'highCenterLabel',
+        consoleOption = 'showHotkeyMessagesInConsole'
+    },
     centerWhite = {
         color = TextColors.white,
         consoleTab = 'Server Log',
@@ -41,6 +51,17 @@ MessageSettings = {
         screenTarget = 'statusLabel',
         consoleOption = 'showStatusMessagesInConsole'
     },
+    statusOwn = {
+        color = TextColors.white,
+        consoleTab = 'Server Log',
+        consoleOption = 'showStatusMessagesInConsole'
+    },
+    statusBoosted = {
+        color = TextColors.white,
+        consoleTab = 'Server Log',
+        screenTarget = 'statusLabel',
+        consoleOption = 'showBoostedMessagesInConsole'
+    },
     othersStatus = {
         color = TextColors.white,
         consoleTab = 'Server Log',
@@ -53,6 +74,48 @@ MessageSettings = {
     private = {
         color = TextColors.lightblue,
         screenTarget = 'privateLabel'
+    },
+    privateRed = {
+        color = TextColors.red,
+        private = true
+    },
+    privatePlayerToPlayer = {
+        color = TextColors.blue,
+        private = true
+    },
+    privatePlayerToNpc = {
+        color = TextColors.blue,
+        private = true,
+        npcChat = true
+    },
+    privateNpcToPlayer = {
+        color = TextColors.lightblue,
+        private = true,
+        npcChat = true
+    },
+    channelYellow = {
+        color = TextColors.yellow
+    },
+    channelWhite = {
+        color = TextColors.white
+    },
+    channelRed = {
+        color = TextColors.red
+    },
+    channelOrange = {
+        color = TextColors.orange
+    },
+    monsterSay = {
+        color = TextColors.orange,
+        hideInConsole = true
+    },
+    monsterYell = {
+        color = TextColors.orange,
+        hideInConsole = true
+    },
+    potion = {
+        color = TextColors.orange,
+        hideInConsole = true
     },
     loot = {
         color = TextColors.white,
@@ -71,8 +134,11 @@ MessageSettings = {
 }
 
 MessageTypes = {
-    [MessageModes.MonsterSay] = MessageSettings.consoleOrange,
-    [MessageModes.MonsterYell] = MessageSettings.consoleOrange,
+    [MessageModes.Say] = MessageSettings.consoleYellow,
+    [MessageModes.Whisper] = MessageSettings.consoleYellow,
+    [MessageModes.Yell] = MessageSettings.consoleYellow,
+    [MessageModes.MonsterSay] = MessageSettings.monsterSay,
+    [MessageModes.MonsterYell] = MessageSettings.monsterYell,
     [MessageModes.BarkLow] = MessageSettings.consoleOrange,
     [MessageModes.BarkLoud] = MessageSettings.consoleOrange,
     [MessageModes.Failure] = MessageSettings.statusSmall,
@@ -84,27 +150,39 @@ MessageTypes = {
     [MessageModes.Loot] = MessageSettings.loot,
     [MessageModes.Red] = MessageSettings.consoleRed,
     [MessageModes.Blue] = MessageSettings.consoleBlue,
-    [MessageModes.PrivateFrom] = MessageSettings.consoleBlue,
+    [MessageModes.PrivateFrom] = MessageSettings.private,
+    [MessageModes.PrivateTo] = MessageSettings.privatePlayerToPlayer,
+    [MessageModes.GamemasterPrivateFrom] = MessageSettings.privateRed,
+    [MessageModes.NpcTo] = MessageSettings.privatePlayerToNpc,
+    [MessageModes.NpcFrom] = MessageSettings.privateNpcToPlayer,
+    [MessageModes.NpcFromStartBlock] = MessageSettings.privateNpcToPlayer,
+    [MessageModes.Channel] = MessageSettings.channelYellow,
+    [MessageModes.ChannelManagement] = MessageSettings.channelWhite,
+    [MessageModes.GamemasterChannel] = MessageSettings.channelRed,
+    [MessageModes.ChannelHighlight] = MessageSettings.channelOrange,
+    [MessageModes.Spell] = MessageSettings.consoleYellow,
+    [MessageModes.RVRChannel] = MessageSettings.channelWhite,
+    [MessageModes.RVRContinue] = MessageSettings.consoleYellow,
 
     [MessageModes.GamemasterBroadcast] = MessageSettings.consoleRed,
 
-    [MessageModes.DamageDealed] = MessageSettings.status,
-    [MessageModes.DamageReceived] = MessageSettings.status,
-    [MessageModes.Heal] = MessageSettings.status,
-    [MessageModes.Exp] = MessageSettings.status,
+    [MessageModes.DamageDealed] = MessageSettings.statusOwn,
+    [MessageModes.DamageReceived] = MessageSettings.statusOwn,
+    [MessageModes.Heal] = MessageSettings.statusOwn,
+    [MessageModes.Exp] = MessageSettings.statusOwn,
 
-    [MessageModes.DamageOthers] = MessageSettings.othersStatus,
-    [MessageModes.HealOthers] = MessageSettings.othersStatus,
-    [MessageModes.ExpOthers] = MessageSettings.othersStatus,
-    [MessageModes.Potion] = MessageSettings.othersStatus,
+    [MessageModes.DamageOthers] = MessageSettings.statusOwn,
+    [MessageModes.HealOthers] = MessageSettings.statusOwn,
+    [MessageModes.ExpOthers] = MessageSettings.statusOwn,
+    [MessageModes.Potion] = MessageSettings.potion,
 
-    [MessageModes.TradeNpc] = MessageSettings.centerWhite,
-    [MessageModes.Guild] = MessageSettings.centerWhite,
-    [MessageModes.Party] = MessageSettings.centerGreen,
-    [MessageModes.PartyManagement] = MessageSettings.centerWhite,
-    [MessageModes.TutorialHint] = MessageSettings.centerWhite,
+    [MessageModes.TradeNpc] = MessageSettings.centerGreen,
+    [MessageModes.Guild] = MessageSettings.statusOwn,
+    [MessageModes.Party] = MessageSettings.statusOwn,
+    [MessageModes.PartyManagement] = MessageSettings.centerGreen,
+    [MessageModes.TutorialHint] = MessageSettings.statusSmall,
     [MessageModes.BeyondLast] = MessageSettings.centerWhite,
-    [MessageModes.Report] = MessageSettings.consoleRed,
+    [MessageModes.Report] = MessageSettings.centerWhite,
     [MessageModes.GameHighlight] = MessageSettings.centerRed,
     [MessageModes.HotkeyUse] = MessageSettings.centerGreen,
     [MessageModes.Attention] = MessageSettings.bottomWhite,

--- a/modules/game_textmessage/textmessage.lua
+++ b/modules/game_textmessage/textmessage.lua
@@ -202,17 +202,6 @@ MessageTypes = {
 messagesPanel = nil
 
 function init()
-    if g_game.getClientVersion() >= 1300 then
-        MessageTypes[MessageModes.Loot] = MessageSettings.loot
-        MessageTypes[MessageModes.ValuableLoot] = MessageSettings.valuableLoot
-        MessageTypes[MessageModes.Guild] = MessageSettings.statusOwn
-        MessageTypes[MessageModes.Party] = MessageSettings.statusOwn
-    else
-        MessageTypes[MessageModes.Loot] = MessageSettings.centerGreen
-        MessageTypes[MessageModes.ValuableLoot] = MessageSettings.centerGreen
-        MessageTypes[MessageModes.Guild] = MessageSettings.centerGreen
-        MessageTypes[MessageModes.Party] = MessageSettings.centerGreen
-    end
     for messageMode, _ in pairs(MessageTypes) do
         registerMessageMode(messageMode, displayMessage)
     end
@@ -241,7 +230,17 @@ function displayMessage(mode, text)
     if not g_game.isOnline() then
         return
     end
-
+    if g_game.getClientVersion() >= 1300 then
+        MessageTypes[MessageModes.Loot] = MessageSettings.loot
+        MessageTypes[MessageModes.ValuableLoot] = MessageSettings.valuableLoot
+        MessageTypes[MessageModes.Guild] = MessageSettings.statusOwn
+        MessageTypes[MessageModes.Party] = MessageSettings.statusOwn
+    else
+        MessageTypes[MessageModes.Loot] = MessageSettings.centerGreen
+        MessageTypes[MessageModes.ValuableLoot] = MessageSettings.centerGreen
+        MessageTypes[MessageModes.Guild] = MessageSettings.centerGreen
+        MessageTypes[MessageModes.Party] = MessageSettings.centerGreen
+    end
     local msgtype = MessageTypes[mode]
     if not msgtype then
         return


### PR DESCRIPTION
# Description

 I only tested at 10.98 and 14.12.

<img width="1056" height="425" alt="image" src="https://github.com/user-attachments/assets/62911370-e7cb-4abc-98af-44994a8651cc" />


## Type of change



  - [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested

make a for  about this
## 10.98
```lua
local MESSAGE_CLASSES_1098 = {
  { id = 4,  name = "MESSAGE_STATUS_CONSOLE_BLUE" },
  { id = 13, name = "MESSAGE_GAMEMASTER_CONSOLE" },
  { id = 17, name = "MESSAGE_LOGIN" },
  { id = 18, name = "MESSAGE_ADMINISTRATOR" },
  { id = 19, name = "MESSAGE_EVENT_ADVANCE" },
  { id = 21, name = "MESSAGE_FAILURE" },
  { id = 22, name = "MESSAGE_LOOK" },
  { id = 23, name = "MESSAGE_DAMAGE_DEALT" },
  { id = 24, name = "MESSAGE_DAMAGE_RECEIVED" },
  { id = 25, name = "MESSAGE_HEALED" },
  { id = 26, name = "MESSAGE_EXPERIENCE" },
  { id = 27, name = "MESSAGE_DAMAGE_OTHERS" },
  { id = 28, name = "MESSAGE_HEALED_OTHERS" },
  { id = 29, name = "MESSAGE_EXPERIENCE_OTHERS" },
  { id = 30, name = "MESSAGE_STATUS" },
  { id = 31, name = "MESSAGE_LOOT" },
  { id = 33, name = "MESSAGE_GUILD" },
  { id = 34, name = "MESSAGE_PARTY_MANAGEMENT" },
  { id = 35, name = "MESSAGE_PARTY" },
  { id = 36, name = "MESSAGE_EVENT_ORANGE" },
  { id = 37, name = "MESSAGE_STATUS_CONSOLE_ORANGE" },
}

for cls in MESSAGE_CLASSES_1098:
    player:sendTextMessage(cls["id"], text)
```

## 14.12
```lua
local MESSAGE_CLASSES_1412 = {
  { id = 0,  name = "MESSAGE_NONE" },
  { id = 13, name = "MESSAGE_GAMEMASTER_CONSOLE" },
  { id = 17, name = "MESSAGE_LOGIN" },
  { id = 18, name = "MESSAGE_ADMINISTRATOR" },
  { id = 19, name = "MESSAGE_EVENT_ADVANCE" },
  { id = 20, name = "MESSAGE_GAME_HIGHLIGHT" },
  { id = 21, name = "MESSAGE_FAILURE" },
  { id = 22, name = "MESSAGE_LOOK" },
  { id = 23, name = "MESSAGE_DAMAGE_DEALT" },
  { id = 24, name = "MESSAGE_DAMAGE_RECEIVED" },
  { id = 25, name = "MESSAGE_HEALED" },
  { id = 26, name = "MESSAGE_EXPERIENCE" },
  { id = 27, name = "MESSAGE_DAMAGE_OTHERS" },
  { id = 28, name = "MESSAGE_HEALED_OTHERS" },
  { id = 29, name = "MESSAGE_EXPERIENCE_OTHERS" },
  { id = 30, name = "MESSAGE_STATUS" },
  { id = 31, name = "MESSAGE_LOOT" },
  { id = 32, name = "MESSAGE_TRADE" },
  { id = 33, name = "MESSAGE_GUILD" },
  { id = 34, name = "MESSAGE_PARTY_MANAGEMENT" },
  { id = 35, name = "MESSAGE_PARTY" },
  { id = 38, name = "MESSAGE_REPORT" },
  { id = 39, name = "MESSAGE_HOTKEY_PRESSED" },
  { id = 40, name = "MESSAGE_TUTORIAL_HINT" },
  { id = 42, name = "MESSAGE_MARKET" },
  { id = 44, name = "MESSAGE_BEYOND_LAST" },
  { id = 48, name = "MESSAGE_ATTENTION" },
  { id = 49, name = "MESSAGE_BOOSTED_CREATURE" },
  { id = 50, name = "MESSAGE_OFFLINE_TRAINING" },
  { id = 51, name = "MESSAGE_TRANSACTION" },
  { id = 52, name = "MESSAGE_POTION" },
}
for cls in MESSAGE_CLASSES_1412:
    player:sendTextMessage(cls["id"], text)    
```
