### PR TITLE
fix: findItem api search ammo slot

### DIFF
--- a/mods/game_bot/functions/player.lua
+++ b/mods/game_bot/functions/player.lua
@@ -159,6 +159,10 @@ context.findItem = function(itemId, subType)
   if subType == nil then
     subType = -1
   end
+  local ammo = context.player:getInventoryItem(InventorySlotAmmo)
+  if ammo and ammo:getId() == itemId and (subType == -1 or ammo:getSubType() == subType) then
+    return ammo
+  end
   return g_game.findItemInContainers(itemId, subType)
 end
 


### PR DESCRIPTION
# Description

previously, if you had a rope in the ammo slot, the findItem api would miss it.

resolves https://github.com/mehah/otclient/issues/1580


## Behavior

### **Actual**

findItem api ignores ammo slot

### **Expected**

findItem api should find items in arrow slot.

## Fixes

#1580 

## Type of change

Please delete options that are not relevant.

  - [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested

tested in-game.

**Test Configuration**:

  - Server Version:
  - Client:
  - Operating System:

## Checklist

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [x] I checked the PR checks reports
  - [ ] I have commented my code, particularly in hard-to-understand areas
  - [ ] I have made corresponding changes to the documentation
  - [x] My changes generate no new warnings
  - [ ] I have added tests that prove my fix is effective or that my feature works
