### PR TITLE
fix:shadowed money variable in parsePlayerGoods

### DIFF
--- a/src/client/protocolgameparse.cpp
+++ b/src/client/protocolgameparse.cpp
@@ -1702,7 +1702,6 @@ void ProtocolGame::parsePlayerGoods(const InputMessagePtr& msg) const
     if (g_game.getClientVersion() >= 1281) {
         money = m_localPlayer->getTotalMoney();
     } else {
-        uint64_t money;
         if (g_game.getFeature(Otc::GameDoublePlayerGoodsMoney))
             money = msg->getU64();
         else


### PR DESCRIPTION
# Description

This PR fixes a variable shadowing bug in `ProtocolGame::parsePlayerGoods`.

For client versions < 1281, an inner declaration of `uint64_t money`
shadowed the outer variable, causing `onPlayerGoods` to always receive
`money = 0`. As a result, NPC trade incorrectly showed "Your Money: 0 gold"
and buy actions were blocked or non-functional.

The fix removes the inner declaration and correctly assigns to the outer
variable.

<img width="1918" height="1033" alt="proof" src="https://github.com/user-attachments/assets/a8e599cb-b96e-4ff1-95b9-fa046ad362f3" />


## Behavior

### **Actual**

NPC trade window always displays "Your Money: 0 gold" even when the player
has gold in the backpack. The Buy button is disabled or buy actions do
nothing.

### **Expected**

NPC trade correctly displays the player's available money and buy actions
work as expected.

## Fixes

N/A (no existing issue was found)

## Type of change

Please delete options that are not relevant.

  - [X] Bug fix (non-breaking change which fixes an issue)
  - [ ] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [ ] This change requires a documentation update

## How Has This Been Tested

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- Built OTClient with the fix applied
- Connected to a ForgottenServer Downgrade (8.6) instance
- Opened NPC trade with gold present in the backpack
- Verified that "Your Money" displays the correct value
- Verified that buying items from NPC works correctly

**Test Configuration**:

- Server Version: ForgottenServer Downgrade (8.6)
- Client: OTClient (mehah)
- Operating System: Windows 11 (MSVC) 

## Checklist

  - [X] My code follows the style guidelines of this project
  - [X] I have performed a self-review of my own code
  - [X] I checked the PR checks reports
  - [ ] I have commented my code, particularly in hard-to-understand areas
  - [ ] I have made corresponding changes to the documentation
  - [X] My changes generate no new warnings
  - [ ] I have added tests that prove my fix is effective or that my feature works
