### PR TITLE
improve: proto appearances.proto compatible with new variables 15.00

### DIFF
--- a/src/client/const.h
+++ b/src/client/const.h
@@ -1061,6 +1061,8 @@ enum ThingFlagAttr :uint64_t
     ThingFlagAttrNPC = static_cast<uint64_t>(1) << 46,
     ThingFlagAttrAmmo = static_cast<uint64_t>(1) << 47,
     ThingFlagAttrFloorChange = static_cast<uint64_t>(1) << 48,
+    ThingFlagAttrDualWield = static_cast<uint64_t>(1) << 49,
+    ThingFlagAttrSkillWheelGem = static_cast<uint64_t>(1) << 50,
 };
 
 enum STACK_PRIORITY : uint8_t
@@ -1109,11 +1111,8 @@ enum ITEM_CATEGORY : uint8_t
     ITEM_CATEGORY_TIBIA_COINS = 23,
     ITEM_CATEGORY_CREATURE_PRODUCTS = 24,
     ITEM_CATEGORY_QUIVER = 25,
-    ITEM_CATEGORY_TWOHANDWEAPON = 26,
-    ITEM_CATEGORY_HELMETS = 27,
-    ITEM_CATEGORY_BACKPACK = 28,
-    ITEM_CATEGORY_ONEHANDWEAPON = 29,
-    ITEM_CATEGORY_ARROW = 30
+    ITEM_CATEGORY_SOUL_CORES = 26,
+    ITEM_CATEGORY_FIST_WEAPONS = 27,
 };
 
 enum SpriteMask :uint8_t

--- a/src/client/luafunctions.cpp
+++ b/src/client/luafunctions.cpp
@@ -786,6 +786,7 @@ void Client::registerLuaFunctions()
     g_lua.bindClassMemberFunction<Item>("hasClockExpire", &Item::hasClockExpire);
     g_lua.bindClassMemberFunction<Item>("hasExpire", &Item::hasExpire);
     g_lua.bindClassMemberFunction<Item>("hasExpireStop", &Item::hasExpireStop);
+    g_lua.bindClassMemberFunction<Item>("isDualWield", &Item::isDualWield);
 #ifdef FRAMEWORK_EDITOR
     g_lua.bindClassMemberFunction<Item>("getName", &Item::getName);
     g_lua.bindClassMemberFunction<Item>("getServerId", &Item::getServerId);

--- a/src/client/luafunctions.cpp
+++ b/src/client/luafunctions.cpp
@@ -750,6 +750,10 @@ void Client::registerLuaFunctions()
     g_lua.bindClassMemberFunction<ThingType>("getName", &ThingType::getName);
     g_lua.bindClassMemberFunction<ThingType>("getDescription", &ThingType::getDescription);
     g_lua.bindClassMemberFunction<ThingType>("isAmmo", &ThingType::isAmmo);
+    g_lua.bindClassMemberFunction<ThingType>("isDualWield", &ThingType::isDualWield);
+    g_lua.bindClassMemberFunction<ThingType>("hasSkillWheelGem", &ThingType::hasSkillWheelGem);
+    g_lua.bindClassMemberFunction<ThingType>("getSkillWheelGemQualityId", &ThingType::getSkillWheelGemQualityId);
+    g_lua.bindClassMemberFunction<ThingType>("getSkillWheelGemVocationId", &ThingType::getSkillWheelGemVocationId);
 #ifdef FRAMEWORK_EDITOR
     g_lua.bindClassMemberFunction<ThingType>("exportImage", &ThingType::exportImage);
 #endif

--- a/src/client/thing.cpp
+++ b/src/client/thing.cpp
@@ -557,6 +557,12 @@ bool Thing::isAmmo() {
     return false;
 }
 
+bool Thing::isDualWield() {
+    if (const auto t = getThingType(); t)
+        return t->isDualWield();
+    return false;
+}
+
 PLAYER_ACTION Thing::getDefaultAction() {
     if (const auto t = getThingType(); t)
         return t->getDefaultAction();

--- a/src/client/thing.h
+++ b/src/client/thing.h
@@ -160,6 +160,7 @@ public:
     bool hasAnimationPhases() const;
     bool isDecoKit() const;
     bool isAmmo();
+    bool isDualWield();
 
     PLAYER_ACTION getDefaultAction();
     uint16_t getClassification();

--- a/src/client/thingtype.cpp
+++ b/src/client/thingtype.cpp
@@ -113,10 +113,6 @@ void ThingType::unserializeAppearance(const uint16_t clientId, const ThingCatego
 
 void ThingType::applyAppearanceFlags(const appearances::AppearanceFlags& flags)
 {
-    if (flags.floorchange()) {
-        m_flags |= ThingFlagAttrFloorChange;
-    }
-
     if (flags.has_bank()) {
         m_groundSpeed = flags.bank().waypoints();
         m_flags |= ThingFlagAttrGround;
@@ -368,6 +364,16 @@ void ThingType::applyAppearanceFlags(const appearances::AppearanceFlags& flags)
 
     if (flags.has_deco_kit() && flags.deco_kit()) {
         m_flags |= ThingFlagAttrExpireStop;
+    }
+
+    if (flags.has_skillwheel_gem()) {
+        m_skillWheelGem.gem_quality_id = flags.skillwheel_gem().gem_quality_id();
+        m_skillWheelGem.vocation_id = flags.skillwheel_gem().vocation_id();
+        m_flags |= ThingFlagAttrSkillWheelGem;
+    }
+
+    if (flags.has_dual_wielding() && flags.dual_wielding()) {
+        m_flags |= ThingFlagAttrDualWield;
     }
 }
 

--- a/src/client/thingtype.h
+++ b/src/client/thingtype.h
@@ -37,6 +37,13 @@ using namespace otclient::protobuf;
 class ThingType final : public LuaObject
 {
 public:
+    struct SkillWheelGem {
+        uint32_t gem_quality_id = 0;
+        uint32_t vocation_id = 0;
+
+        uint32_t getGemQualityId() { return gem_quality_id; }
+        uint32_t getVocationId() { return vocation_id; }
+    };
     void unserializeAppearance(uint16_t clientId, ThingCategory category, const appearances::Appearance& appearance);
     void unserialize(uint16_t clientId, ThingCategory category, const FileStreamPtr& fin);
     void unserializeOtml(const OTMLNodePtr& node);
@@ -140,9 +147,16 @@ public:
     bool isTopEffect() { return (m_flags & ThingFlagAttrTopEffect); }
     bool hasAction() { return (m_flags & ThingFlagAttrDefaultAction); }
     bool isOpaque() { return m_opaque == 1; }
+    
+    uint32_t getSkillWheelGemQualityId() { return m_skillWheelGem.gem_quality_id; }
+    uint32_t getSkillWheelGemVocationId() { return m_skillWheelGem.vocation_id; }
+
     bool isDecoKit() { return (m_flags & ThingFlagAttrDecoKit); }
     bool isLoading() const { return m_loading.load(std::memory_order_acquire); }
     bool isAmmo() { return (m_flags & ThingFlagAttrAmmo); }
+    bool isDualWield() { return (m_flags & ThingFlagAttrDualWield); }
+    bool hasSkillWheelGem() { return (m_flags & ThingFlagAttrSkillWheelGem); }
+    SkillWheelGem getSkillWheelGem() { return m_skillWheelGem; }
 
     bool isItem() const { return m_category == ThingCategoryItem; }
     bool isEffect() const { return m_category == ThingCategoryEffect; }
@@ -244,4 +258,5 @@ private:
 
     std::string m_name;
     std::string m_description;
+    SkillWheelGem m_skillWheelGem;
 };

--- a/src/protobuf/appearances.proto
+++ b/src/protobuf/appearances.proto
@@ -42,12 +42,8 @@ enum ITEM_CATEGORY {
 	ITEM_CATEGORY_TIBIA_COINS = 23;
 	ITEM_CATEGORY_CREATURE_PRODUCTS = 24;
 	ITEM_CATEGORY_QUIVER = 25;
-	ITEM_CATEGORY_TWOHANDWEAPON = 26;
-	ITEM_CATEGORY_HELMETS = 27;
-	ITEM_CATEGORY_BACKPACK = 28;
-	ITEM_CATEGORY_ONEHANDWEAPON = 29;
-	ITEM_CATEGORY_ARROW = 30;
-	ITEM_CATEGORY_SOULCORES = 31;
+	ITEM_CATEGORY_SOUL_CORES = 26;
+	ITEM_CATEGORY_FIST_WEAPONS = 27;
 }
 
 enum PLAYER_PROFESSION {
@@ -185,12 +181,12 @@ message AppearanceFlags {
 	optional bool expire = 55;
 	optional bool expirestop = 56;
 	optional bool deco_kit = 57;
+	optional AppearanceFlagSkillWheelGem skillwheel_gem = 58;
 	optional bool dual_wielding = 59;
-	reserved 58, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69;
+	reserved 60, 61, 62, 63, 64, 65, 66, 67, 68, 69;
 	optional bool hook_south = 70;
 	optional bool hook_east = 71;
 	optional AppearanceFlagTransparencyLevel transparencylevel = 72;
-	optional bool floorchange = 73;
 }
 
 message AppearanceFlagUpgradeClassification {
@@ -272,6 +268,11 @@ message AppearanceFlagChangedToExpire {
 
 message AppearanceFlagCyclopedia {
 	optional uint32 cyclopedia_type = 1;
+}
+
+message AppearanceFlagSkillWheelGem {
+  optional uint32 gem_quality_id = 1;
+  optional uint32 vocation_id = 2;
 }
 
 message SpecialMeaningAppearanceIds {


### PR DESCRIPTION
No significant changes, just cleaning up and adding new variables.
```cpp
    g_lua.bindClassMemberFunction<Item>("isDualWield", &Item::isDualWield);
```
It may be used in game_inventory for monk. `item:isDualWield()`

source:
https://github.com/Arch-Mina/Assets-Editor/blob/main/Assets%20Editor/appearances.proto
https://github.com/opentibiabr/canary/blob/dudantas/feat-monk/src/protobuf/appearances.proto
