### PR TITLE
feat: remove magic effect

### DIFF
--- a/src/client/protocolgameparse.cpp
+++ b/src/client/protocolgameparse.cpp
@@ -36,6 +36,7 @@
 #include "missile.h"
 #include "thingtype.h"
 #include "thingtypemanager.h"
+#include "tile.h"
 #include "framework/core/eventdispatcher.h"
 #include "framework/net/inputmessage.h"
 #include "paperdollmanager.h"
@@ -1859,13 +1860,23 @@ void ProtocolGame::parseMagicEffect(const InputMessagePtr& msg)
 
 void ProtocolGame::parseRemoveMagicEffect(const InputMessagePtr& msg)
 {
-    getPosition(msg);
-    uint16_t effectId = g_game.getFeature(Otc::GameEffectU16) ? msg->getU16() : msg->getU8();
+    const auto& pos = getPosition(msg);
+    const uint16_t effectId = g_game.getFeature(Otc::GameEffectU16) ? msg->getU16() : msg->getU8();
+
     if (!g_things.isValidDatId(effectId, ThingCategoryEffect)) {
         g_logger.warning("[ProtocolGame::parseRemoveMagicEffect] - Invalid effectId type {}", effectId);
         return;
     }
-    // TO-DO
+
+    const auto& tile = g_map.getTile(pos);
+    if (!tile)
+        return;
+
+    const auto& effect = tile->getEffect(effectId);
+    if (!effect)
+        return;
+
+    g_map.removeThing(effect);
 }
 
 void ProtocolGame::parseAnimatedText(const InputMessagePtr& msg)


### PR DESCRIPTION
# Description

Implemented the parseRemoveMagicEffect method in ProtocolGame to correctly remove magic effects from map tiles when instructed by the server. Previously, the method parsed the network message but did not perform the actual removal logic.

## Behavior

### **Actual**

When the server sends a RemoveMagicEffect packet, the client parses the position and effect ID but does not remove the effect from the map, causing visual artifacts and desync between client and server state.

### **Expected**

When the server sends a RemoveMagicEffect packet, the client correctly removes the specified magic effect from the tile at the given position, keeping the client state synchronized with the server.

## Fixes

\# (issue)

## Type of change

  - [x] New feature (non-breaking change which adds functionality)

## Checklist

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [x] I checked the PR checks reports
  - [x] My changes generate no new warnings


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced magic effect removal with improved validation to verify target tiles and effects exist before removal operations.
  * Strengthened error handling to gracefully manage cases where target tiles or magic effects are missing, preventing invalid removal attempts.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->