### PR TITLE
fix: further optimize color to_lower_ascii

### DIFF
--- a/src/framework/util/color.cpp
+++ b/src/framework/util/color.cpp
@@ -133,9 +133,8 @@ namespace {
 
     inline std::string to_lower_ascii(std::string_view s) {
         std::string out(s);
-        for (char &c : out)
-            if (c >= 'A' && c <= 'Z')
-                c |= 0x20;
+        for (char& c : out)
+            c += (c >= 'A' && c <= 'Z') ? 0x20 : 0;
         return out;
     }
 


### PR DESCRIPTION
one less branch, and it really shows on microbenchmarks:  https://quick-bench.com/q/pxrI9X9kVtpApj4iIeYnolxgfz4
- 1.6 times faster than https://github.com/opentibiabr/otclient/pull/1490
- 7.2 times faster than the original pre-1490 tolower.

how has this been tested?: https://wandbox.org/permlink/wJG4CS4oghvlwQxZ

<img width="937" height="469" alt="image" src="https://github.com/user-attachments/assets/109a73c0-6ab7-4af3-a354-7e54236d7838" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Minor code style improvements to internal utilities with no impact on functionality or user experience.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->