### PR TITLE
fix: private messages duplicated in console/local chat

### DIFF
--- a/modules/game_textmessage/textmessage.lua
+++ b/modules/game_textmessage/textmessage.lua
@@ -282,7 +282,27 @@ function displayMessage(mode, text)
 end
 
 function displayPrivateMessage(text)
-    displayMessage(254, text)
+    if not g_game.isOnline() then
+        return
+    end
+    
+    local msgtype = MessageSettings.private
+    if not msgtype or not msgtype.screenTarget then
+        return
+    end
+    
+    local label = messagesPanel:recursiveGetChildById(msgtype.screenTarget)
+    if not label then
+        return
+    end
+    
+    label:setText(text)
+    label:setColor(msgtype.color)
+    label:setVisible(true)
+    removeEvent(label.hideEvent)
+    label.hideEvent = scheduleEvent(function()
+        label:setVisible(false)
+    end, calculateVisibleTime(text))
 end
 
 function displayStatusMessage(text)


### PR DESCRIPTION
## Bug: Private messages duplicated in Local Chat

### Problem Description

Private messages were being displayed twice:
1. In the private chat tab (correct)
2. In the Local Chat tab (duplicate/incorrect)

Additionally:
- Messages appeared with incorrect line breaks
- When the private chat tab was closed, messages appeared in Local Chat but without the ability to click on the player name to open a private message

<img width="341" height="131" alt="image" src="https://github.com/user-attachments/assets/32708a97-de18-4eaf-8415-fcc28d03668d" />

### Root Cause

The `displayPrivateMessage()` function was calling `displayMessage(254, text)`, which added the message to the console via `addText()` with `consoleTab = 'Local Chat'`. This caused duplication because private messages are already processed via `onTalk -> addPrivateText()`.

### Solution

Modified `displayPrivateMessage()` to only display messages on screen (screenTarget) without adding them to the console, since console handling is already done via `onTalk`:

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved private message display reliability with enhanced validation checks and timing controls.
  * Private messages now automatically hide after the appropriate duration as intended.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->