### PR TITLE
fix: black flicker caused by opacity not resetting

### DIFF
--- a/src/client/attachedeffect.cpp
+++ b/src/client/attachedeffect.cpp
@@ -80,7 +80,8 @@ void AttachedEffect::draw(const Point& dest, const bool isOnTop, LightView* ligh
     if (m_transform)
         return;
 
-    if (m_texture != nullptr || getThingType() != nullptr) {
+    auto* thingType = getThingType();
+    if (m_texture != nullptr || thingType != nullptr) {
         const auto& dirControl = m_offsetDirections[m_direction];
         if (dirControl.onTop != isOnTop)
             return;
@@ -94,6 +95,12 @@ void AttachedEffect::draw(const Point& dest, const bool isOnTop, LightView* ligh
             if (animation == 0 && --m_loop == 0)
                 return;
         }
+
+        // Check if the thing type can actually be drawn before setting opacity/shader
+        // This prevents stale state from affecting subsequent draws when this effect
+        // returns early due to missing texture or invalid state
+        if (!m_texture && thingType && (thingType->isNull() || thingType->getAnimationPhases() == 0))
+            return;
 
         if (m_shader) g_drawPool.setShaderProgram(m_shader, true);
         if (m_opacity < 100) g_drawPool.setOpacity(getOpacity(), true);
@@ -134,7 +141,7 @@ void AttachedEffect::draw(const Point& dest, const bool isOnTop, LightView* ligh
                 g_drawPool.addTexturedRect(Rect(point, size), texture, rect, Color::white);
             }
         } else {
-            getThingType()->draw(point, 0, m_direction, 0, 0, animation, Color::white, drawThing, lightView);
+            thingType->draw(point, 0, m_direction, 0, 0, animation, Color::white, drawThing, lightView);
         }
 
         g_drawPool.setDrawOrder(lastDrawOrder);

--- a/src/client/attachedeffect.cpp
+++ b/src/client/attachedeffect.cpp
@@ -102,17 +102,22 @@ void AttachedEffect::draw(const Point& dest, const bool isOnTop, LightView* ligh
         if (!m_texture && thingType && (thingType->isNull() || thingType->getAnimationPhases() == 0))
             return;
 
-        if (m_shader) g_drawPool.setShaderProgram(m_shader, true);
-        if (m_opacity < 100) g_drawPool.setOpacity(getOpacity(), true);
 
         const auto scaleFactor = g_drawPool.getScaleFactor();
 
-        if (m_pulse.height > 0 && m_pulse.speed > 0) {
-            g_drawPool.setScaleFactor(scaleFactor + getBounce(m_pulse) / 100.f);
-        }
+        // Only set shader, opacity, pulse and fade when actually drawing things
+        // to prevent stale state from affecting subsequent draws
+        if (drawThing) {
+            if (m_shader) g_drawPool.setShaderProgram(m_shader, true);
+            if (m_opacity < 100) g_drawPool.setOpacity(getOpacity(), true);
 
-        if (m_fade.height > 0 && m_fade.speed > 0) {
-            g_drawPool.setOpacity(std::clamp<float>(getBounce(m_fade) / 100.f, 0, 1.f));
+            if (m_pulse.height > 0 && m_pulse.speed > 0) {
+                g_drawPool.setScaleFactor(scaleFactor + getBounce(m_pulse) / 100.f);
+            }
+
+            if (m_fade.height > 0 && m_fade.speed > 0) {
+                g_drawPool.setOpacity(std::clamp<float>(getBounce(m_fade) / 100.f, 0, 1.f));
+            }
         }
 
         auto point = dest - (dirControl.offset * g_drawPool.getScaleFactor());
@@ -146,12 +151,14 @@ void AttachedEffect::draw(const Point& dest, const bool isOnTop, LightView* ligh
 
         g_drawPool.setDrawOrder(lastDrawOrder);
 
-        if (m_pulse.height > 0 && m_pulse.speed > 0) {
-            g_drawPool.setScaleFactor(scaleFactor);
-        }
+        if (drawThing) {
+            if (m_pulse.height > 0 && m_pulse.speed > 0) {
+                g_drawPool.setScaleFactor(scaleFactor);
+            }
 
-        if (m_fade.height > 0 && m_fade.speed > 0) {
-            g_drawPool.resetOpacity();
+            if (m_fade.height > 0 && m_fade.speed > 0) {
+                g_drawPool.resetOpacity();
+            }
         }
     }
 

--- a/src/client/effect.cpp
+++ b/src/client/effect.cpp
@@ -81,6 +81,13 @@ void Effect::draw(const Point& dest, const bool drawThings, LightView* lightView
             yPattern += getNumPatternY();
     }
 
+    // Check if the effect can actually be drawn before setting opacity/shader
+    // This prevents stale state from affecting subsequent draws when this effect
+    // returns early due to missing texture or invalid state
+    auto* thingType = getThingType();
+    if (!thingType || thingType->isNull() || thingType->getAnimationPhases() == 0)
+        return;
+
     if (g_drawPool.getCurrentType() == DrawPoolType::MAP) {
         if (drawThings && g_client.getEffectAlpha() < 1.f)
             g_drawPool.setOpacity(g_client.getEffectAlpha(), true);
@@ -89,7 +96,7 @@ void Effect::draw(const Point& dest, const bool drawThings, LightView* lightView
     if (hasShader())
         g_drawPool.setShaderProgram(g_shaders.getShaderById(m_shaderId), true/*, shaderAction*/);
 
-    getThingType()->draw(dest, 0, xPattern, yPattern, 0, animationPhase, Color::white, drawThings, lightView);
+    thingType->draw(dest, 0, xPattern, yPattern, 0, animationPhase, Color::white, drawThings, lightView);
 }
 
 void Effect::onAppear()

--- a/src/client/effect.cpp
+++ b/src/client/effect.cpp
@@ -93,7 +93,7 @@ void Effect::draw(const Point& dest, const bool drawThings, LightView* lightView
             g_drawPool.setOpacity(g_client.getEffectAlpha(), true);
     }
 
-    if (hasShader())
+    if (drawThings && hasShader())
         g_drawPool.setShaderProgram(g_shaders.getShaderById(m_shaderId), true/*, shaderAction*/);
 
     thingType->draw(dest, 0, xPattern, yPattern, 0, animationPhase, Color::white, drawThings, lightView);

--- a/src/client/missile.cpp
+++ b/src/client/missile.cpp
@@ -36,6 +36,13 @@ void Missile::draw(const Point& dest, const bool drawThings, LightView* lightVie
     if (!canDraw() || isHided())
         return;
 
+    // Check if the missile can actually be drawn before setting opacity/shader
+    // This prevents stale state from affecting subsequent draws when this missile
+    // returns early due to missing texture or invalid state
+    auto* thingType = getThingType();
+    if (!thingType || thingType->isNull() || thingType->getAnimationPhases() == 0)
+        return;
+
     const float fraction = m_duration > 0 ? m_animationTimer.ticksElapsed() / m_duration : 1;
 
     if (g_drawPool.getCurrentType() == DrawPoolType::MAP) {
@@ -47,7 +54,7 @@ void Missile::draw(const Point& dest, const bool drawThings, LightView* lightVie
     if (hasShader())
         g_drawPool.setShaderProgram(g_shaders.getShaderById(m_shaderId), true/*, shaderAction*/);
 
-    getThingType()->draw(dest + m_delta * fraction * g_drawPool.getScaleFactor(), 0, m_numPatternX, m_numPatternY, 0, 0, Color::white, drawThings, lightView);
+    thingType->draw(dest + m_delta * fraction * g_drawPool.getScaleFactor(), 0, m_numPatternX, m_numPatternY, 0, 0, Color::white, drawThings, lightView);
     g_drawPool.resetDrawOrder();
 }
 

--- a/src/client/missile.cpp
+++ b/src/client/missile.cpp
@@ -51,7 +51,7 @@ void Missile::draw(const Point& dest, const bool drawThings, LightView* lightVie
             g_drawPool.setOpacity(g_client.getMissileAlpha(), true);
     }
 
-    if (hasShader())
+    if (drawThings && hasShader())
         g_drawPool.setShaderProgram(g_shaders.getShaderById(m_shaderId), true/*, shaderAction*/);
 
     thingType->draw(dest + m_delta * fraction * g_drawPool.getScaleFactor(), 0, m_numPatternX, m_numPatternY, 0, 0, Color::white, drawThings, lightView);

--- a/src/client/thingtype.cpp
+++ b/src/client/thingtype.cpp
@@ -694,6 +694,10 @@ void ThingType::draw(const Point& dest, const int layer, const int xPattern, con
             drawWithFrameBuffer(texture, screenRect, textureRect, newColor);
         else
             g_drawPool.addTexturedRect(screenRect, texture, textureRect, newColor);
+    } else {
+        // Reset any pending onlyOnce state when not drawing things
+        // to prevent stale opacity/shader from affecting subsequent draws
+        g_drawPool.resetOnlyOnceParameters();
     }
 
     if (lightView && hasLight()) {

--- a/src/client/thingtype.h
+++ b/src/client/thingtype.h
@@ -37,7 +37,8 @@ using namespace otclient::protobuf;
 class ThingType final : public LuaObject
 {
 public:
-    struct SkillWheelGem {
+    struct SkillWheelGem
+    {
         uint32_t gem_quality_id = 0;
         uint32_t vocation_id = 0;
 
@@ -60,7 +61,7 @@ public:
 
     uint16_t getId() { return m_id; }
     ThingCategory getCategory() { return m_category; }
-    bool isNull() { return m_null; }
+    bool isNull() const { return m_null; }
     bool hasAttr(const ThingAttr attr) { return (m_flags & thingAttrToThingFlagAttr(attr)); }
 
     int getWidth() { return m_size.width(); }
@@ -71,7 +72,7 @@ public:
     int getNumPatternX() { return m_numPatternX; }
     int getNumPatternY() { return m_numPatternY; }
     int getNumPatternZ() { return m_numPatternZ; }
-    int getAnimationPhases();
+    int getAnimationPhases() const;
     Animator* getAnimator() const { return m_animator; }
     Animator* getIdleAnimator() const { return m_idleAnimator; }
 
@@ -147,7 +148,7 @@ public:
     bool isTopEffect() { return (m_flags & ThingFlagAttrTopEffect); }
     bool hasAction() { return (m_flags & ThingFlagAttrDefaultAction); }
     bool isOpaque() { return m_opaque == 1; }
-    
+
     uint32_t getSkillWheelGemQualityId() { return m_skillWheelGem.gem_quality_id; }
     uint32_t getSkillWheelGemVocationId() { return m_skillWheelGem.vocation_id; }
 

--- a/src/framework/graphics/drawpool.h
+++ b/src/framework/graphics/drawpool.h
@@ -277,20 +277,23 @@ private:
 
     void resetOnlyOnceParameters() {
         if (m_onlyOnceStateFlag > 0) { // Only Once State
+            // Restore previous values instead of resetting to defaults
             if (m_onlyOnceStateFlag & STATE_OPACITY)
-                resetOpacity();
+                getCurrentState().opacity = m_previousOpacity;
 
             if (m_onlyOnceStateFlag & STATE_BLEND_EQUATION)
-                resetBlendEquation();
+                getCurrentState().blendEquation = m_previousBlendEquation;
 
             if (m_onlyOnceStateFlag & STATE_CLIP_RECT)
-                resetClipRect();
+                getCurrentState().clipRect = m_previousClipRect;
 
             if (m_onlyOnceStateFlag & STATE_COMPOSITE_MODE)
-                resetCompositionMode();
+                getCurrentState().compositionMode = m_previousCompositionMode;
 
-            if (m_onlyOnceStateFlag & STATE_SHADER_PROGRAM)
-                resetShaderProgram();
+            if (m_onlyOnceStateFlag & STATE_SHADER_PROGRAM) {
+                getCurrentState().shaderProgram = m_previousShaderProgram;
+                getCurrentState().action = m_previousShaderAction;
+            }
 
             m_onlyOnceStateFlag = 0;
         }
@@ -314,6 +317,14 @@ private:
     uint16_t m_refreshDelay{ 0 }, m_shaderRefreshDelay{ 0 };
     uint32_t m_onlyOnceStateFlag{ 0 };
     uint_fast64_t m_lastFramebufferId{ 0 };
+
+    // Store previous values before onlyOnce override to restore them correctly
+    float m_previousOpacity{ 1.f };
+    BlendEquation m_previousBlendEquation{ BlendEquation::ADD };
+    CompositionMode m_previousCompositionMode{ CompositionMode::NORMAL };
+    Rect m_previousClipRect;
+    PainterShaderProgram* m_previousShaderProgram{ nullptr };
+    std::function<void()> m_previousShaderAction{ nullptr };
 
     PoolState m_states[10];
     uint_fast8_t m_lastStateIndex{ 0 };

--- a/src/framework/graphics/drawpoolmanager.h
+++ b/src/framework/graphics/drawpoolmanager.h
@@ -76,6 +76,7 @@ public:
     void resetShaderProgram() const { getCurrentPool()->resetShaderProgram(); }
     void resetCompositionMode() const { getCurrentPool()->resetCompositionMode(); }
     void resetDrawOrder() const { getCurrentPool()->resetDrawOrder(); }
+    void resetOnlyOnceParameters() const { getCurrentPool()->resetOnlyOnceParameters(); }
 
     void pushTransformMatrix() const { getCurrentPool()->pushTransformMatrix(); }
     void popTransformMatrix() const { getCurrentPool()->popTransformMatrix(); }


### PR DESCRIPTION
**Note: I am not a C++ expert; anyone with more experience is welcome to review and improve the PR if they wish.**

# Description

This change fixes an intermittent black flickering issue caused by an incorrect render state being preserved when temporary rendering parameters were applied with `onlyOnce`.

The rendering pipeline allows temporary states (such as opacity and shaders) to be applied using the `onlyOnce` mechanism, which should automatically reset after a successful draw call. However, in certain edge cases, the draw routine exited early before the reset occurred, causing subsequent objects to inherit an unintended opacity state.

This resulted in tiles, items, or other objects being rendered darker or nearly black, depending on texture transparency, render order, and asynchronous asset loading.

No external dependencies are required for this change.

## Behavior

### **Actual**

When an effect sets opacity using `setOpacity(value, true)` and the draw process returns early (e.g. due to asynchronous texture loading or invalid `ThingType` data), the render state is not reset.  
Subsequent objects inherit the incorrect opacity, causing intermittent black or dark flickering.

### **Expected**

Temporary render states applied with `onlyOnce` are always cleared, even if a draw call exits early.  
Subsequent objects render with the correct opacity and no visual flickering occurs.

## Fixes

[(issue 1602)](https://github.com/opentibiabr/otclient/issues/1602)

## Type of change

Please delete options that are not relevant.

  - [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested

The fix was validated by reproducing scenarios where effects attempted to draw while textures were still loading asynchronously or when invalid `ThingType` data was present.

Tests confirmed that the render state is now properly reset in all early-return paths, preventing opacity leakage into subsequent draw calls.

  - [x] Rendering effects while textures are loading asynchronously
  - [x] Rendering tiles and items immediately after failed or skipped effect draws

## Checklist

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [x] I checked the PR checks reports
  - [x] I have commented my code, particularly in hard-to-understand areas
  - [x] My changes generate no new warnings


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved rendering stability by skipping draw steps when visual assets are missing or invalid, avoiding stale-state visual glitches.
  * Ensured shader, opacity, pulse and fade effects are only applied when an object is actually drawn.
  * Prevented one-shot rendering overrides from leaking into subsequent frames by resetting or restoring prior rendering parameters on early-exit or hash-miss.

* **Refactor**
  * Internal handling of temporary render-state now restores previous values after one-shot overrides.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->