### PR TITLE
fix: colored loot text

### DIFF
--- a/src/framework/graphics/bitmapfont.cpp
+++ b/src/framework/graphics/bitmapfont.cpp
@@ -454,11 +454,9 @@ std::string BitmapFont::wrapText(std::string_view text, int maxWidth, const Wrap
 
     auto pushChar = [&](char ch) {
         out.push_back(ch);
-        if (colors) updateColors(colors, (int)out.size() - 1, 1);
     };
     auto pushSlice = [&](const char* s, int n) {
-        size_t o = out.size(); out.append(s, s + n);
-        if (colors) updateColors(colors, (int)o, n);
+        out.append(s, s + n);
     };
     auto newline = [&]() {
         out.push_back('\n');


### PR DESCRIPTION
# Description

Fixes missing loot highlight in wrap func. Thanks @InnerCircleTFS 

<img width="2233" height="1307" alt="image" src="https://github.com/user-attachments/assets/09a94ac6-1f09-4d5a-a7bb-1917c96f4a9e" />


## Behavior

### **Actual**

Do this and that doesn't happens

### **Expected**

Do this and that happens

## Fixes

#1615 

## Type of change

Please delete options that are not relevant.

  - [X] Bug fix (non-breaking change which fixes an issue)
  - [ ] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [ ] This change requires a documentation update

## How Has This Been Tested

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

  - [ ] Test A
  - [ ] Test B

**Test Configuration**:

  - Server Version: CANARY
  - Client: OTCR
  - Operating System: W11

## Checklist

  - [X] My code follows the style guidelines of this project
  - [X] I have performed a self-review of my own code
  - [X] I checked the PR checks reports
  - [X] I have commented my code, particularly in hard-to-understand areas
  - [X] I have made corresponding changes to the documentation
  - [X] My changes generate no new warnings
  - [X] I have added tests that prove my fix is effective or that my feature works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved color tracking efficiency during text wrapping operations. Color metadata updates are now optimized to avoid redundant processing while maintaining proper formatting output.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->