### PR TITLE
fix: creature name too close to health bar

### DIFF
--- a/src/client/creature.cpp
+++ b/src/client/creature.cpp
@@ -204,6 +204,12 @@ void Creature::drawInformation(const MapPosInfo& mapRect, const Point& dest, con
     auto backgroundRect = Rect(p.x - (15.5), p.y - cropSizeBackGround, 31, 4);
     auto textRect = Rect(p.x - nameSize.width() / 2.0, p.y - cropSizeText, nameSize);
 
+    constexpr int minNameBarSpacing = 2;
+    const int currentSpacing = backgroundRect.top() - textRect.bottom();
+    if (currentSpacing < minNameBarSpacing) {
+        backgroundRect.moveTop(textRect.bottom() + minNameBarSpacing);
+    }
+
     if (!isScaled) {
         backgroundRect.bind(parentRect);
         textRect.bind(parentRect);


### PR DESCRIPTION
Before:

<img width="431" height="197" alt="image" src="https://github.com/user-attachments/assets/9fb25b3a-0f52-43d4-801c-7c3bf0db68bf" />

After:

<img width="318" height="235" alt="image" src="https://github.com/user-attachments/assets/64b88c6c-cd46-4b54-bb8f-8b346ff49429" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced creature name display with improved vertical spacing between background and text elements.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->