### PR TITLE
fix: tab name text offset

### DIFF
--- a/modules/game_console/console.otui
+++ b/modules/game_console/console.otui
@@ -62,11 +62,11 @@ ConsoleTabBarButton < UIButton
   image-source: /images/ui/console_button
   image-clip: 0 18 96 18
   color: #7f7f7fff
+  text-offset: 0 -1
   font: verdana-11px-rounded
   anchors.top: parent.top
   anchors.left: parent.left
   padding: 5
-  tab-spacing: 0
   padding-left: 20
   padding-right: 20
   &tabWidth: 95

--- a/modules/game_console/console.otui
+++ b/modules/game_console/console.otui
@@ -67,6 +67,7 @@ ConsoleTabBarButton < UIButton
   anchors.top: parent.top
   anchors.left: parent.left
   padding: 5
+  tab-spacing: 0
   padding-left: 20
   padding-right: 20
   &tabWidth: 95


### PR DESCRIPTION
# Description

This adjustment realigns the tab name so that it no longer appears at the bottom.


### **Actual**

<img width="257" height="37" alt="image" src="https://github.com/user-attachments/assets/94724e11-dd4f-47cf-9bb1-9d4965ad6072" />


### **Expected**

<img width="541" height="486" alt="Screenshot_3" src="https://github.com/user-attachments/assets/3b43fdaa-2e32-4e3e-8baf-9b2da2bebee1" />


## Type of change

Please delete options that are not relevant.

  - [x] Bug fix (non-breaking change which fixes an issue)
  - [ ] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [ ] This change requires a documentation update





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted text positioning in the game console tab bar buttons for improved visual alignment and consistency with the overall interface design.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->