### PR TITLE
fix: message box auto-adjust

### DIFF
--- a/modules/client_entergame/entergame.lua
+++ b/modules/client_entergame/entergame.lua
@@ -798,7 +798,7 @@ function EnterGame.doLogin()
         protocolLogin.onUpdateNeeded = onUpdateNeeded
 
         loadBox = displayCancelBox(tr('Please wait'), tr('Connecting to login server...'))
-        loadBox:setWidth(200)
+
         connect(loadBox, {
             onCancel = function(msgbox)
                 loadBox = nil


### PR DESCRIPTION
# Description

Correcting the automatic adjustment of the box according to the message size, eliminating the fixed box size.

## Before

<img width="784" height="388" alt="Screenshot_2" src="https://github.com/user-attachments/assets/c9548df5-0a4a-4eeb-8066-cb1bb2ef89d5" />


### **Expected**

<img width="1145" height="520" alt="Screenshot_3" src="https://github.com/user-attachments/assets/255a1cc6-a6f8-41b1-bf40-7c48ddc33315" />

Please delete options that are not relevant.

  - [x] Bug fix (non-breaking change which fixes an issue)
  - [ ] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [ ] This change requires a documentation update


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed unnecessary width assignment in the login dialog, streamlining the initialization process.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->