### PR TITLE
fix: increase cavebot lure count max to 30

### DIFF
--- a/mods/game_bot/default_configs/cavebot_1.3/targetbot/creature_editor.lua
+++ b/mods/game_bot/default_configs/cavebot_1.3/targetbot/creature_editor.lua
@@ -80,7 +80,7 @@ TargetBot.Creature.edit = function(config, callback) -- callback = function(newC
   addScrollBar("danger", "Danger", 0, 10, 1)
   addScrollBar("maxDistance", "Max distance", 1, 10, 10)
   addScrollBar("keepDistanceRange", "Keep distance", 1, 5, 1)
-  addScrollBar("lureCount", "Lure", 0, 5, 1)
+  addScrollBar("lureCount", "Lure", 0, 30, 1)
 
   addScrollBar("minMana", "Min. mana for attack spell", 0, 3000, 200)
   addScrollBar("attackSpellDelay", "Attack spell delay", 200, 5000, 2500)

--- a/mods/game_bot/default_configs/cavebot_1.3/targetbot_configs/config_name.json
+++ b/mods/game_bot/default_configs/cavebot_1.3/targetbot_configs/config_name.json
@@ -30,7 +30,7 @@
       "groupAttackIgnorePlayers": true,
       "maxDistance": 10,
       "groupAttackIgnoreParty": false,
-      "lureCount": 5,
+      "lureCount": 30,
       "useGroupAttack": false,
       "groupRuneAttackTargets": 2,
       "attackSpell": "",


### PR DESCRIPTION
# Description

- sometimes luring more than 5 is beneficial.
- there is no obvious architectural reason for the existing max-5-limit.
- vBot already support up to 30

<img width="1899" height="1228" alt="image" src="https://github.com/user-attachments/assets/d2208ff4-75f4-42bd-a32f-ee16f6c5940d" />


## Behavior


### **Actual**

lure count is capped to 5 for no good reason

### **Expected**

allow luring more than 5

## Fixes

\# (issue)

## Type of change

Please delete options that are not relevant.

  - [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested

**Test Configuration**:

  - Server Version:
  - Client:
  - Operating System:

## Checklist

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [ ] I checked the PR checks reports
  - [ ] I have commented my code, particularly in hard-to-understand areas
  - [ ] I have made corresponding changes to the documentation
  - [x] My changes generate no new warnings
  - [ ] I have added tests that prove my fix is effective or that my feature works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration Updates**
  * Increased maximum lure count parameter from 5 to 30 in creature editor and targetbot settings, enabling higher targeting thresholds.

* **Improvements**
  * Enhanced configuration file structure and formatting for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->