### PR TITLE
fix: correct bitmap bounds calculation in glyph rendering

### DIFF
--- a/src/framework/graphics/ttfloader.cpp
+++ b/src/framework/graphics/ttfloader.cpp
@@ -379,19 +379,19 @@ BitmapFontPtr TTFLoader::load(const std::string &file, int fontSize,
           const int strokeLeft = strokeBitmapGlyph->left;
           const int strokeTop = strokeBitmapGlyph->top;
 
-          const int copyWidth =
-              std::min((int)strokeBitmap.width, glyphsSize[i].width());
-          const int copyHeight =
-              std::min((int)strokeBitmap.rows, glyphsSize[i].height());
-
           // Draw stroke
           if (strokeBitmap.buffer && strokeBitmap.pitch != 0) {
             const int pitch = (int)strokeBitmap.pitch;
             const int bmpRows = (int)strokeBitmap.rows;
+            const int absPitch = std::abs(pitch);
+
+            // Constrain by actual buffer size per row (pitch) and destination size
+            const int copyWidth = std::min({absPitch, (int)strokeBitmap.width, glyphsSize[i].width()});
+            const int copyHeight = std::min((int)strokeBitmap.rows, glyphsSize[i].height());
 
             for (int y = 0; y < copyHeight; ++y) {
               const int rowOffset = (pitch > 0) ? (y * pitch)
-                                               : ((bmpRows - 1 - y) * -pitch);
+                                               : ((bmpRows - 1 - y) * absPitch);
               for (int x = 0; x < copyWidth; ++x) {
                 const int srcIdx = rowOffset + x;
                 const int dstX = atlasX + x;
@@ -487,18 +487,18 @@ BitmapFontPtr TTFLoader::load(const std::string &file, int fontSize,
         if (FT_Render_Glyph(slot, FT_RENDER_MODE_NORMAL) == 0) {
           const FT_Bitmap &bitmap = slot->bitmap;
 
-          const int copyWidth =
-              std::min((int)bitmap.width, glyphsSize[i].width());
-          const int copyHeight =
-              std::min((int)bitmap.rows, glyphsSize[i].height());
-
           if (bitmap.buffer && bitmap.pitch != 0) {
             const int pitch = (int)bitmap.pitch;
             const int bmpRows = (int)bitmap.rows;
+            const int absPitch = std::abs(pitch);
+
+            // Constrain by actual buffer size per row (pitch) and destination size
+            const int copyWidth = std::min({absPitch, (int)bitmap.width, glyphsSize[i].width()});
+            const int copyHeight = std::min((int)bitmap.rows, glyphsSize[i].height());
 
             for (int y = 0; y < copyHeight; ++y) {
               const int rowOffset = (pitch > 0) ? (y * pitch)
-                                               : ((bmpRows - 1 - y) * -pitch);
+                                               : ((bmpRows - 1 - y) * absPitch);
               for (int x = 0; x < copyWidth; ++x) {
                 const int srcIdx = rowOffset + x;
                 const int dstX = atlasX + x;


### PR DESCRIPTION
# Description

Fixed an small issue where glyph sizes were crashing the game on open using the debug options.

## Behavior

### **Actual**

<img width="1113" height="614" alt="image" src="https://github.com/user-attachments/assets/f238ae22-9798-4d12-84cd-335097315b75" />

### **Expected**

<img width="1379" height="620" alt="image" src="https://github.com/user-attachments/assets/a4fd2cf0-01f0-4298-b077-b890ee839ede" />

## Fixes

\# (issue)

## Type of change

Please delete options that are not relevant.

  - [X] Bug fix (non-breaking change which fixes an issue)
  - [ ] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [ ] This change requires a documentation update

## How Has This Been Tested

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

  - [ ] Test A
  - [ ] Test B

**Test Configuration**:

  - Server Version: Canary 1500
  - Client: OTCR
  - Operating System: W11

## Checklist

  - [X] My code follows the style guidelines of this project
  - [X] I have performed a self-review of my own code
  - [X] I checked the PR checks reports
  - [X] I have commented my code, particularly in hard-to-understand areas
  - [X] I have made corresponding changes to the documentation
  - [X] My changes generate no new warnings
  - [X] I have added tests that prove my fix is effective or that my feature works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed font rendering to properly handle bitmap data in all orientations, ensuring consistent and correct glyph display across various font configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->