### PR TITLE
fix(#1649):  Cyclopedia: fix charm removal from monster in 14.12

### DIFF
--- a/modules/game_cyclopedia/game_cyclopedia.lua
+++ b/modules/game_cyclopedia/game_cyclopedia.lua
@@ -529,7 +529,7 @@ function SelectWindow(type, isBackButtonPress)
 end
 
 function Cyclopedia.onResourcesBalanceChange()
-    if not controllerCyclopedia.ui:isVisible() then
+    if not controllerCyclopedia.ui or not controllerCyclopedia.ui:isVisible() then
         return
     end
 

--- a/modules/game_cyclopedia/game_cyclopedia.lua
+++ b/modules/game_cyclopedia/game_cyclopedia.lua
@@ -79,6 +79,7 @@ function controllerCyclopedia:onGameStart()
         g_ui.importStyle("cyclopedia_pages")
 
         controllerCyclopedia:registerEvents(g_game, {
+            onResourcesBalanceChange = Cyclopedia.onResourcesBalanceChange,
             -- bestiary
             onParseBestiaryRaces = Cyclopedia.loadBestiaryCategories,
             onParseBestiaryOverview = Cyclopedia.loadBestiaryOverview,
@@ -98,7 +99,7 @@ function controllerCyclopedia:onGameStart()
             onUpdateCyclopediaCharacterItemSummary = Cyclopedia.loadCharacterItems,
             onParseCyclopediaCharacterAppearances = Cyclopedia.loadCharacterAppearances,
             onParseCyclopediaStoreSummary = Cyclopedia.onParseCyclopediaStoreSummary,
--- character 14.10
+            -- character 14.10
             onCyclopediaCharacterOffenceStats = Cyclopedia.onCyclopediaCharacterOffenceStats,
             onCyclopediaCharacterDefenceStats = Cyclopedia.onCyclopediaCharacterDefenceStats,
             onCyclopediaCharacterMiscStats = Cyclopedia.onCyclopediaCharacterMiscStats,
@@ -493,7 +494,7 @@ function show(defaultWindow)
     controllerCyclopedia.ui:raise()
     controllerCyclopedia.ui:focus()
     SelectWindow(defaultWindow, false)
-    controllerCyclopedia.ui.GoldBase.Value:setText(Cyclopedia.formatGold(g_game.getLocalPlayer():getResourceBalance()))
+    controllerCyclopedia.ui.GoldBase.Value:setText(Cyclopedia.formatGold(g_game.getLocalPlayer():getTotalMoney()))
 end
 
 function toggleBack()
@@ -524,5 +525,31 @@ function SelectWindow(type, isBackButtonPress)
         if window.func then
             window.func(contentContainer)
         end
+    end
+end
+
+function Cyclopedia.onResourcesBalanceChange()
+    if not controllerCyclopedia.ui:isVisible() then
+        return
+    end
+
+    local player = g_game.getLocalPlayer()
+    if not player then
+        return
+    end
+
+    controllerCyclopedia.ui.GoldBase.Value:setText(Cyclopedia.formatGold(player:getTotalMoney()))
+
+    local formatResourceBalance = function(resourceType, maxResourceType)
+        return string.format("%d/%d", player:getResourceBalance(resourceType),
+            player:getResourceBalance(maxResourceType))
+    end
+
+    controllerCyclopedia.ui.CharmsBase.Value:setText(formatResourceBalance(ResourceTypes.CHARM,
+        ResourceTypes.MAX_CHARM))
+
+    if controllerCyclopedia.ui.CharmsBase1410:isVisible() then
+        controllerCyclopedia.ui.CharmsBase1410.Value:setText(formatResourceBalance(
+            ResourceTypes.MINOR_CHARM, ResourceTypes.MAX_MINOR_CHARM))
     end
 end

--- a/modules/game_cyclopedia/tab/charms/charms.lua
+++ b/modules/game_cyclopedia/tab/charms/charms.lua
@@ -338,8 +338,8 @@ function Cyclopedia.CreateCharmItem(data)
     end
 
     local player = g_game.getLocalPlayer()
-    if widget.icon == 1 and player:getResourceBalance(ResourceTypes.GOLD_EQUIPPED) then
-        local canAfford = data.removeRuneCost <= player:getResourceBalance(ResourceTypes.GOLD_EQUIPPED)
+    if widget.icon == 1 and player:getTotalMoney() then
+        local canAfford = data.removeRuneCost <= player:getTotalMoney()
         value:setColor(canAfford and "#C0C0C0" or "#D33C3C")
     elseif widget.icon == 0 then
         local canAfford = data.unlockPrice <= UI.CharmsPoints
@@ -375,11 +375,16 @@ function Cyclopedia.loadCharms(charmsData)
             ResourceTypes.MAX_CHARM))
         controllerCyclopedia.ui.CharmsBase1410.Value:setText(
             formatResourceBalance(ResourceTypes.MINOR_CHARM, ResourceTypes.MAX_MINOR_CHARM))
+        local canAfford = charmsData.resetAllCharmsCost <= player:getTotalMoney()
+        UI.anotherPanel.CharmsBase1410.Value:setText(Cyclopedia.formatGold(charmsData.resetAllCharmsCost))
+        UI.anotherPanel.CharmsBase1410.Value:setColor(canAfford and "#BDBDBD" or "#D33C3C")
+        UI.anotherPanel.resetAllButton:setEnabled(canAfford)
     else
         controllerCyclopedia.ui.CharmsBase.Value:setText(Cyclopedia.formatGold(charmsData.points))
     end
 
     UI.CharmsPoints = charmsData.points
+    UI.resetAllCharmsCost = charmsData.resetAllCharmsCost
 
     Cyclopedia.Charms.Monsters = {}
     local raceIdNamePairs = {}
@@ -479,7 +484,7 @@ local function getUIBase()
             ItemBase = UI.InformationBase.ItemBase,
             PriceBase = UI.InformationBase.verticalPanelUnLockClearChram.PriceBaseGold,
             UnlockButton = UI.InformationBase.verticalPanelUnLockClearChram.UnlockButton,
-            SearchEdit = UI.InformationBase.PanelCreatureList.SearchEdit.SearchEdit,
+            SearchEdit = UI.InformationBase.PanelCreatureList.SearchPanel.SearchEdit,
             SearchLabel = UI.InformationBase.SearchLabel,
             CreaturesBase = UI.InformationBase.PanelCreatureList.CreaturesBase,
             CreaturesLabel = UI.InformationBase.panelSelectCreature.CreaturesLabel
@@ -527,12 +532,13 @@ local function updateUIColors(widget, UI_BASE)
             UI.InformationBase.verticalPanelUnLockClearChram.PriceBaseCharm.Value:setColor("#C0C0C0")
             UI.InformationBase.verticalPanelUnLockClearChram.UnlockButton:setEnabled(false)
         end
-        if not widget.data.asignedStatus then
-            priceValue:setText(0)
-        end
+        priceValue:setText(comma_value(widget.data.removeRuneCost))
+        local canAfford = widget.data.removeRuneCost <= player:getTotalMoney()
+        priceValue:setColor(canAfford and "#C0C0C0" or "#D33C3C")
+        UI.InformationBase.verticalPanelUnLockClearChram.ClearButton:setEnabled(canAfford and widget.data.asignedStatus)
     else
-        if widget.icon == 1 and player:getResourceBalance(ResourceTypes.GOLD_EQUIPPED) then
-            local canAfford = widget.data.removeRuneCost <= player:getResourceBalance(ResourceTypes.GOLD_EQUIPPED)
+        if widget.icon == 1 and player:getTotalMoney() then
+            local canAfford = widget.data.removeRuneCost <= player:getTotalMoney()
             priceValue:setColor(canAfford and "#C0C0C0" or "#D33C3C")
             UI_BASE.UnlockButton:setEnabled(canAfford)
 
@@ -662,20 +668,22 @@ function Cyclopedia.selectCharm(widget, isChecked)
         creatureWidget:setEnabled(false)
         creatureWidget:setColor("#707070")
 
-        UI_BASE.SearchEdit:setEnabled(false)
-        if UI_BASE.SearchLabel then
-            UI_BASE.SearchLabel:setEnabled(false)
+        if not isModernUI then
+            UI_BASE.SearchEdit:setEnabled(false)
+            if UI_BASE.SearchLabel then
+                UI_BASE.SearchLabel:setEnabled(false)
+            end
+            UI_BASE.CreaturesLabel:setEnabled(false)
         end
-        UI_BASE.CreaturesLabel:setEnabled(false)
     end
 
     if not widget.data.unlocked then
         UI_BASE.UnlockButton:setText("Unlock")
-        UI_BASE.SearchEdit:setEnabled(false)
-        if UI_BASE.SearchLabel then
-            UI_BASE.SearchLabel:setEnabled(false)
-        end
         if not isModernUI then
+            UI_BASE.SearchEdit:setEnabled(false)
+            if UI_BASE.SearchLabel then
+                UI_BASE.SearchLabel:setEnabled(false)
+            end
             UI_BASE.CreaturesLabel:setEnabled(false)
         end
     end
@@ -980,6 +988,113 @@ function Cyclopedia.actionSelectCharmButton(widget)
                     },
                     anchor = AnchorHorizontalCenter
                 }, yesCallback, noCallback)
+        end
+    end
+end
+
+function Cyclopedia.clearCharm()
+    local confirmWindow
+    local data = UI.InformationBase.data
+    if not data then
+        return
+    end
+
+    local charm = charms[data.id]
+    if not charm then
+        return
+    end
+
+    local function yesCallback()
+        g_game.BuyCharmRune(2, data.id, 0)
+        if confirmWindow then
+            confirmWindow:destroy()
+            confirmWindow = nil
+        end
+    end
+
+    local function noCallback()
+        if confirmWindow then
+            confirmWindow:destroy()
+            confirmWindow = nil
+        end
+    end
+
+    if not confirmWindow then
+        confirmWindow = displayGeneralBox("Confirm Charm Removal",
+            string.format("Do you want to remove the Charm %s from this creature? This will cost you %s gold pieces.",
+                charm.name, comma_value(data.removeRuneCost)), {
+                {
+                    text = "Yes",
+                    callback = yesCallback
+                },
+                {
+                    text = "No",
+                    callback = noCallback
+                },
+                anchor = AnchorHorizontalCenter
+            }, yesCallback, noCallback)
+    end
+end
+
+function Cyclopedia.resetAllCharms()
+    if not UI or not UI.resetAllCharmsCost then
+        return
+    end
+
+    local title = "Confirm Reset of Charms"
+    local text = string.format("Do you want to reset all Charms? This will cost you %s gold?",
+        comma_value(UI.resetAllCharmsCost))
+
+    local yesCallback = function()
+        g_game.BuyCharmRune(3, -58, 0)
+        if UI.displayGeneralBox then
+            UI.displayGeneralBox:destroy()
+            UI.displayGeneralBox = nil
+        end
+    end
+
+    local noCallback = function()
+        if UI.displayGeneralBox then
+            UI.displayGeneralBox:destroy()
+            UI.displayGeneralBox = nil
+        end
+    end
+
+    if UI.displayGeneralBox then
+        UI.displayGeneralBox:destroy()
+    end
+
+    UI.displayGeneralBox = displayGeneralBox(title, text, {
+        {
+            text = 'Yes',
+            callback = yesCallback
+        },
+        {
+            text = 'No',
+            callback = noCallback
+        }
+    }, yesCallback, noCallback)
+end
+
+function Cyclopedia.onSearchTextChange(text, panel)
+    local creaturesBase = panel:getChildById('CreaturesBase')
+    if not creaturesBase then
+        return
+    end
+
+    local creatureList = creaturesBase:getChildById('CreatureList')
+    if not creatureList then
+        return
+    end
+
+    local children = creatureList:getChildren()
+    text = text:lower()
+    for _, child in ipairs(children) do
+        local name = child:getText():lower()
+        if name:find(text, 1, true) then
+            child:show()
+        else
+            child:hide()
         end
     end
 end

--- a/modules/game_cyclopedia/tab/charms/charms1410.otui
+++ b/modules/game_cyclopedia/tab/charms/charms1410.otui
@@ -85,13 +85,13 @@ UIWidget
           image-source: /game_cyclopedia/images/monster-icon-bonuspoints
 
       QtButton
-        id: check
+        id: ClearButton
         anchors.top: prev.bottom
         anchors.left: parent.left
         anchors.right: parent.right
-        text: Addon 1
-        margin-top:3
         text: Clear Charm
+        margin-top: 3
+        @onClick: modules.game_cyclopedia.Cyclopedia.clearCharm()
 
 
       UIWidget
@@ -120,12 +120,38 @@ UIWidget
       id: PanelCreatureList
       width: 140
       margin-left: 5
-      TextEditQuestLog
-        id:SearchEdit
+      Panel
+        id: SearchPanel
         height: 20
         anchors.top: parent.top
         anchors.left: parent.left
         anchors.right: parent.right
+
+        TextEdit
+          id: SearchEdit
+          anchors.fill: parent
+          margin-left: 5
+          height: 17
+          placeholder: Type to search
+          placeholder-color: #6E706F
+          @onTextChange: modules.game_cyclopedia.Cyclopedia.onSearchTextChange(self:getText(), self:getParent():getParent())
+
+        UIWidget
+          id: SearchClearButton
+          anchors.right: SearchEdit.right
+          anchors.top: SearchEdit.top
+          margin-top: 1
+          margin-right: 2
+          image-source: /game_cyclopedia/images/button_clear_search
+          image-color: white
+          opacity: 0.8
+          @onClick: self:getParent():getChildById('SearchEdit'):clearText()
+          $hover:
+            opacity: 1.0
+            image-color: white
+          $pressed:
+            opacity: 1.0
+            image-color: gray
       BorderBox
         id: CreaturesBase
         anchors.top: prev.bottom
@@ -197,11 +223,13 @@ UIWidget
     margin-left: 5
 
     QtButton
+      id: resetAllButton
       text: Reset all charms
       anchors.left: parent.left
       anchors.right: parent.right
       anchors.verticalCenter: parent.verticalCenter
       margin-top: -15
+      @onClick: modules.game_cyclopedia.Cyclopedia.resetAllCharms()
 
     UIWidget
       id: CharmsBase1410

--- a/src/client/luavaluecasts_client.cpp
+++ b/src/client/luavaluecasts_client.cpp
@@ -845,9 +845,15 @@ int push_luavalue(const CharmData& charm) {
 }
 
 int push_luavalue(const BestiaryCharmsData& charmData) {
-    g_lua.createTable(0, 3);
+    g_lua.createTable(0, 5);
     g_lua.pushInteger(charmData.points);
     g_lua.setField("points");
+
+    g_lua.pushInteger(charmData.resetAllCharmsCost);
+    g_lua.setField("resetAllCharmsCost");
+
+    g_lua.pushInteger(charmData.availableCharmSlots);
+    g_lua.setField("availableCharmSlots");
 
     g_lua.createTable(charmData.charms.size(), 0);
     for (size_t i = 0; i < charmData.charms.size(); ++i) {


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Behavior

### **Actual**

Do this and that doesn't happens

### **Expected**

Do this and that happens

## Fixes

#1649

## Type of change

Please delete options that are not relevant.

  - [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested

test in 14.12

**Test Configuration**:

  - Server Version: 14.12
  - Client: this pr
  - Operating System: win

## Checklist

  - [x] My code follows the style guidelines of this project


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Clear Charm confirmation with cost display and Reset All Charms workflow with total-cost preview
  * Live creature search box with clear button

* **Changes**
  * Affordability checks now use total available money; button states and color indicators updated
  * Search and reset controls repositioned and adjusted for modern UI

* **Chores**
  * Resource balance displays refreshed across the Cyclopedia UI
<!-- end of auto-generated comment: release notes by coderabbit.ai -->