### PR TITLE
fix: orange textmessage in Old Protocol

### DIFF
--- a/modules/game_textmessage/textmessage.lua
+++ b/modules/game_textmessage/textmessage.lua
@@ -240,6 +240,8 @@ function displayMessage(mode, text)
         MessageTypes[MessageModes.ValuableLoot] = MessageSettings.centerGreen
         MessageTypes[MessageModes.Guild] = MessageSettings.centerGreen
         MessageTypes[MessageModes.Party] = MessageSettings.centerGreen
+        MessageTypes[MessageModes.MonsterSay] = MessageSettings.consoleOrange
+        MessageTypes[MessageModes.MonsterYell] = MessageSettings.consoleOrange
     end
     local msgtype = MessageTypes[mode]
     if not msgtype then


### PR DESCRIPTION
# Description

<img width="188" height="22" alt="image" src="https://github.com/user-attachments/assets/072afe38-937f-4590-9370-fd5f9e7710fa" />

## Behavior

### **Actual**

Do this and that doesn't happens

### **Expected**

Do this and that happens

## Fixes

\# (issue)

## Type of change

Please delete options that are not relevant.

  - [ ] Bug fix (non-breaking change which fixes an issue)
  - [ ] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [ ] This change requires a documentation update

## How Has This Been Tested

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

  - [ ] Test A
  - [ ] Test B

**Test Configuration**:

  - Server Version:
  - Client:
  - Operating System:

## Checklist

  - [ ] My code follows the style guidelines of this project
  - [ ] I have performed a self-review of my own code
  - [ ] I checked the PR checks reports
  - [ ] I have commented my code, particularly in hard-to-understand areas
  - [ ] I have made corresponding changes to the documentation
  - [ ] My changes generate no new warnings
  - [ ] I have added tests that prove my fix is effective or that my feature works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Updated the console display for monster messages to enhance visibility and readability for players using older game client versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->