### PR TITLE
feat(vBot): add Monk vocation (5/15) support across bot scripts

### DIFF
--- a/mods/game_bot/default_configs/vBot_4.8/vBot/AttackBot.lua
+++ b/mods/game_bot/default_configs/vBot_4.8/vBot/AttackBot.lua
@@ -431,7 +431,7 @@ local spellPatterns = {
 }
 
 -- direction patterns
-local ek = (voc() == 1 or voc() == 11) and true
+local ek = (voc() == 1 or voc() == 11 or voc() == 5 or voc() == 15) and true
 
 local posN = ek and [[
   111

--- a/mods/game_bot/default_configs/vBot_4.8/vBot/Sio.lua
+++ b/mods/game_bot/default_configs/vBot_4.8/vBot/Sio.lua
@@ -39,7 +39,8 @@ Panel
       healEk = false,
       healRp = false,
       healEd = false,
-      healMs = false
+      healMs = false,
+      healEm = false
     }
   end
 
@@ -114,6 +115,11 @@ Panel
       config.healRp = not config.healRp
       widget:setOn(config.healRp)
     end
+    sioListWindow.vocation.EM:setOn(config.healEm)
+    sioListWindow.vocation.EM.onClick = function(widget)
+      config.healEm = not config.healEm
+      widget:setOn(config.healEm)
+    end
 
     -- functions
     local updateMinManaText = function()
@@ -172,6 +178,7 @@ Panel
     elseif voc == 12 then voc = 2
     elseif voc == 13 then voc = 3
     elseif voc == 14 then voc = 4
+    elseif voc == 15 then voc = 5
     end
 
     local isOk = false
@@ -182,6 +189,8 @@ Panel
     elseif voc == 3 and config.healMs then
       isOk = true
     elseif voc == 4 and config.healEd then
+      isOk = true
+    elseif voc == 5 and config.healEm then
       isOk = true
     end
 

--- a/mods/game_bot/default_configs/vBot_4.8/vBot/cast_food.lua
+++ b/mods/game_bot/default_configs/vBot_4.8/vBot/cast_food.lua
@@ -1,5 +1,5 @@
 setDefaultTab("HP")
-if voc() ~= 1 and voc() ~= 11 then
+if voc() ~= 1 and voc() ~= 11 and voc() ~= 5 and voc() ~= 15 then
     if storage.foodItems then
         local t = {}
         for i, v in pairs(storage.foodItems) do

--- a/mods/game_bot/default_configs/vBot_4.8/vBot/eat_food.lua
+++ b/mods/game_bot/default_configs/vBot_4.8/vBot/eat_food.lua
@@ -1,5 +1,5 @@
 setDefaultTab("HP")
-if voc() ~= 1 and voc() ~= 11 then
+if voc() ~= 1 and voc() ~= 11 and voc() ~= 5 and voc() ~= 15 then
     if storage.foodItems then
         local t = {}
         for i, v in pairs(storage.foodItems) do

--- a/mods/game_bot/default_configs/vBot_4.8/vBot/exeta.lua
+++ b/mods/game_bot/default_configs/vBot_4.8/vBot/exeta.lua
@@ -1,5 +1,5 @@
 local voc = player:getVocation()
-if voc == 1 or voc == 11 then
+if voc == 1 or voc == 11 or voc == 5 or voc == 15 then
     setDefaultTab("Cave")
     UI.Separator()
     local m = macro(100000, "Exeta when low hp", function() end)

--- a/mods/game_bot/default_configs/vBot_4.8/vBot/extras.lua
+++ b/mods/game_bot/default_configs/vBot_4.8/vBot/extras.lua
@@ -155,6 +155,8 @@ if true then
     vocText = "- MS"
   elseif voc() == 4 or voc() == 14 then
     vocText = "- ED"
+  elseif voc() == 5 or voc() == 15 then
+    vocText = "- EM"
   end
 
   macro(5000, function()
@@ -596,6 +598,8 @@ if true then
         voc = "EK"
       elseif text:lower():find("paladin") then
         voc = "RP"
+      elseif text:lower():find("monk") then
+        voc = "EM"
       end
       local creature = getCreatureByName(name)
       if creature then

--- a/mods/game_bot/default_configs/vBot_4.8/vBot/new_healer.lua
+++ b/mods/game_bot/default_configs/vBot_4.8/vBot/new_healer.lua
@@ -62,6 +62,7 @@ if not storage[panelName] then
             paladins = true,
             druids = false,
             sorcerers = false,
+            monks = true,
             party = true,
             guild = false,
             --botserver = false,
@@ -207,6 +208,13 @@ targetSettings.vocations.box.sorcerers:setChecked(config.conditions.sorcerers)
 targetSettings.vocations.box.sorcerers.onClick = function(widget)
     config.conditions.sorcerers = not config.conditions.sorcerers
     widget:setChecked(config.conditions.sorcerers)
+    validate(widget, 2)
+end
+
+targetSettings.vocations.box.monks:setChecked(config.conditions.monks)
+targetSettings.vocations.box.monks.onClick = function(widget)
+    config.conditions.monks = not config.conditions.monks
+    widget:setChecked(config.conditions.monks)
     validate(widget, 2)
 end
 
@@ -400,7 +408,8 @@ local function isCandidate(spec)
         if specText:find("EK") and not config.conditions.knights or
            specText:find("RP") and not config.conditions.paladins or
            specText:find("ED") and not config.conditions.druids or
-           specText:find("MS") and not config.conditions.sorcerers then
+           specText:find("MS") and not config.conditions.sorcerers or
+           specText:find("EM") and not config.conditions.monks then
            if not config.customPlayers[name] then
                return nil
            end

--- a/mods/game_bot/default_configs/vBot_4.8/vBot/new_healer.lua
+++ b/mods/game_bot/default_configs/vBot_4.8/vBot/new_healer.lua
@@ -29,6 +29,11 @@ if not storage[panelName] or not storage[panelName].priorities then
     storage[panelName] = nil
 end
 
+-- backfill monks condition for existing configs
+if storage[panelName] and storage[panelName].conditions and storage[panelName].conditions.monks == nil then
+    storage[panelName].conditions.monks = true
+end
+
 if not storage[panelName] then
     storage[panelName] = {
         enabled = false,

--- a/mods/game_bot/default_configs/vBot_4.8/vBot/new_healer.otui
+++ b/mods/game_bot/default_configs/vBot_4.8/vBot/new_healer.otui
@@ -176,7 +176,7 @@ Groups < FlatPanel
       text: BotServer Members
 
 Vocations < FlatPanel
-  size: 100 105
+  size: 100 120
   padding: 3
   padding-top: 5
 
@@ -220,6 +220,10 @@ Vocations < FlatPanel
     CategoryCheckBox
       id: sorcerers
       text: Sorcerers
+
+    CategoryCheckBox
+      id: monks
+      text: Monks
 
 Priority < Panel
   size: 190 123

--- a/mods/game_bot/default_configs/vBot_4.8/vBot/playerlist.lua
+++ b/mods/game_bot/default_configs/vBot_4.8/vBot/playerlist.lua
@@ -58,6 +58,10 @@ if g_game.getLocalPlayer():isDead() then return end
             specOutfit.feet = 88
             if storage.BOTserver.outfit then
               local voc = vBot.BotServerMembers[spec:getName()]
+              -- normalize promoted vocation ids (11-15 -> 1-5)
+              if voc and voc > 10 then
+                  voc = voc - 10
+              end
               specOutfit.addons = 3
               if voc == 1 then
                 specOutfit.type = 131
@@ -105,6 +109,10 @@ local checkStatus = function(creature)
         specOutfit.feet = 88
         if storage.BOTserver.outfit then
           local voc = vBot.BotServerMembers[creature:getName()]
+          -- normalize promoted vocation ids (11-15 -> 1-5)
+          if voc and voc > 10 then
+              voc = voc - 10
+          end
           specOutfit.addons = 3
           if voc == 1 then
             specOutfit.type = 131

--- a/mods/game_bot/default_configs/vBot_4.8/vBot/playerlist.lua
+++ b/mods/game_bot/default_configs/vBot_4.8/vBot/playerlist.lua
@@ -67,6 +67,8 @@ if g_game.getLocalPlayer():isDead() then return end
                 specOutfit.type = 130
               elseif voc == 4 then
                 specOutfit.type = 144
+              elseif voc == 5 then
+                specOutfit.type = 152
               end
             end
             spec:setOutfit(specOutfit)
@@ -112,6 +114,8 @@ local checkStatus = function(creature)
             specOutfit.type = 130
           elseif voc == 4 then
             specOutfit.type = 144
+          elseif voc == 5 then
+            specOutfit.type = 152
           end
         end
         creature:setOutfit(specOutfit)

--- a/mods/game_bot/default_configs/vBot_4.8/vBot/siolist.otui
+++ b/mods/game_bot/default_configs/vBot_4.8/vBot/siolist.otui
@@ -2,7 +2,7 @@ VocationPanel < Panel
   padding: 3
   image-source: /images/ui/panel_flat
   image-border: 6
-  size: 190 55
+  size: 190 75
 
   Label
     anchors.top: parent.top
@@ -38,6 +38,13 @@ VocationPanel < Panel
     anchors.left: parent.horizontalCenter
     anchors.right: parent.right
     text: Paladins
+
+  BotSwitch
+    id: EM
+    anchors.bottom: EK.top
+    anchors.left: parent.left
+    anchors.right: parent.right
+    text: Monks
 
 SioListWindow < MainWindow
   !text: tr('Healer Options')


### PR DESCRIPTION
the bot only handled the 4 standard vocations (EK/RP/MS/ED) and completely ignored Monk in every vocation-gated feature — window title, healer, sio, exeta, attackbot, playerlist, food casting, etc.

### changes
- **extras.lua** — window title shows `- EM` for monk, player look detection recognizes `monk` text
- **Sio.lua** — `healEm` config, UI toggle, voc normalization (15->5), isValid filter
- **siolist.otui** — Monks button in the vocation panel
- **new_healer.lua** — `monks` condition in storage defaults, checkbox handler, isCandidate filter for EM
- **new_healer.otui** — Monks checkbox in Vocations panel (height adjusted)
- **playerlist.lua** — outfit type 152 for voc 5 in both marking functions
- **exeta.lua** — monk (5/15) triggers exeta res (melee like EK)
- **AttackBot.lua** — monk uses melee direction patterns
- **eat_food.lua / cast_food.lua** — monk excluded from food spell casting (melee, no exevo pan)

monk is a melee/support hybrid — grouped with EK in the shooter panel but has sio like druid. followed that same behavior here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Monks (EM) vocation support across healing, combat and player-list displays.
  * New "Monks" toggle in healer vocations panel and a Monks switch in vocation UI.
  * Extended vocation handling so promoted vocations are recognized and mapped consistently.
  * Broadened directional and food/casting logic to include the Monks vocation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->