### PR TITLE
feat: add hotkeys support for media keys and others

### DIFF
--- a/modules/corelib/const.lua
+++ b/modules/corelib/const.lua
@@ -186,9 +186,20 @@ KeyNumpad6                   = 147
 KeyNumpad7                   = 148
 KeyNumpad8                   = 149
 KeyNumpad9                   = 150
+KeyBrowserBack               = 166
+KeyBrowserSearch             = 170
+KeyBrowserHome               = 172
+KeyVolumeMute                = 173
+KeyVolumeDown                = 174
+KeyVolumeUp                  = 175
+KeyMediaNext                 = 176
+KeyMediaPrev                 = 177
+KeyMediaPlayPause            = 179
+KeyLaunchMediaSelect         = 181
 
 FirstKey                     = KeyUnknown
-LastKey                      = KeyNumpad9
+LastKey                      = KeyLaunchMediaSelect
+
 
 ExtendedActivate             = 0
 ExtendedLocales              = 1
@@ -312,7 +323,17 @@ KeyCodeDescs                 = {
     [KeyNumpad6] = 'Numpad6',
     [KeyNumpad7] = 'Numpad7',
     [KeyNumpad8] = 'Numpad8',
-    [KeyNumpad9] = 'Numpad9'
+    [KeyNumpad9] = 'Numpad9',
+    [KeyBrowserBack] = 'BrowserBack',
+    [KeyBrowserSearch] = 'BrowserSearch',
+    [KeyBrowserHome] = 'BrowserHome',
+    [KeyVolumeMute] = 'Mute',
+    [KeyVolumeDown] = 'Volume-',
+    [KeyVolumeUp] = 'Volume+',
+    [KeyMediaNext] = 'MediaNext',
+    [KeyMediaPrev] = 'MediaPrev',
+    [KeyMediaPlayPause] = 'PlayPause',
+    [KeyLaunchMediaSelect] = 'MediaLaunch'
 }
 
 NetworkMessageTypes          = {

--- a/src/framework/const.h
+++ b/src/framework/const.h
@@ -170,6 +170,16 @@ namespace Fw
         KeyNumpad7 = 148,
         KeyNumpad8 = 149,
         KeyNumpad9 = 150,
+        KeyBrowserBack = 166,
+        KeyBrowserSearch = 170,
+        KeyBrowserHome = 172,
+        KeyVolumeMute = 173,
+        KeyVolumeDown = 174,
+        KeyVolumeUp = 175,
+        KeyMediaNext = 176,
+        KeyMediaPrev = 177,
+        KeyMediaPlayPause = 179,
+        KeyLaunchMediaSelect = 181,
         KeyLast
     };
 

--- a/src/framework/platform/browserwindow.cpp
+++ b/src/framework/platform/browserwindow.cpp
@@ -144,13 +144,13 @@ BrowserWindow::BrowserWindow() {
     web_keymap.push_back({ "BrowserBack", Fw::KeyBrowserBack });
     web_keymap.push_back({ "BrowserSearch", Fw::KeyBrowserSearch });
     web_keymap.push_back({ "BrowserHome", Fw::KeyBrowserHome });
-    web_keymap.push_back({ "Mute", Fw::KeyVolumeMute });
-    web_keymap.push_back({ "Volume-", Fw::KeyVolumeDown });
-    web_keymap.push_back({ "Volume+", Fw::KeyVolumeUp });
-    web_keymap.push_back({ "MediaNext", Fw::KeyMediaNext });
-    web_keymap.push_back({ "MediaPrev", Fw::KeyMediaPrev });
-    web_keymap.push_back({ "PlayPause", Fw::KeyMediaPlayPause });
-    web_keymap.push_back({ "MediaLaunch", Fw::KeyLaunchMediaSelect });
+    web_keymap.push_back({ "AudioVolumeMute", Fw::KeyVolumeMute });
+    web_keymap.push_back({ "AudioVolumeDown", Fw::KeyVolumeDown });
+    web_keymap.push_back({ "AudioVolumeUp", Fw::KeyVolumeUp });
+    web_keymap.push_back({ "MediaTrackNext", Fw::KeyMediaNext });
+    web_keymap.push_back({ "MediaTrackPrevious", Fw::KeyMediaPrev });
+    web_keymap.push_back({ "MediaPlayPause", Fw::KeyMediaPlayPause });
+    web_keymap.push_back({ "MediaSelect", Fw::KeyLaunchMediaSelect });
     web_keymap.push_back({ 0, Fw::KeyUnknown });
 }
 

--- a/src/framework/platform/browserwindow.cpp
+++ b/src/framework/platform/browserwindow.cpp
@@ -141,6 +141,16 @@ BrowserWindow::BrowserWindow() {
     web_keymap.push_back({ "Backslash", Fw::KeyBackslash });
     web_keymap.push_back({ "BracketRight", Fw::KeyRightBracket });
     web_keymap.push_back({ "Quote", Fw::KeyQuote });
+    web_keymap.push_back({ "BrowserBack", Fw::KeyBrowserBack });
+    web_keymap.push_back({ "BrowserSearch", Fw::KeyBrowserSearch });
+    web_keymap.push_back({ "BrowserHome", Fw::KeyBrowserHome });
+    web_keymap.push_back({ "Mute", Fw::KeyVolumeMute });
+    web_keymap.push_back({ "Volume-", Fw::KeyVolumeDown });
+    web_keymap.push_back({ "Volume+", Fw::KeyVolumeUp });
+    web_keymap.push_back({ "MediaNext", Fw::KeyMediaNext });
+    web_keymap.push_back({ "MediaPrev", Fw::KeyMediaPrev });
+    web_keymap.push_back({ "PlayPause", Fw::KeyMediaPlayPause });
+    web_keymap.push_back({ "MediaLaunch", Fw::KeyLaunchMediaSelect });
     web_keymap.push_back({ 0, Fw::KeyUnknown });
 }
 

--- a/src/framework/platform/win32window.cpp
+++ b/src/framework/platform/win32window.cpp
@@ -217,6 +217,16 @@ WIN32Window::WIN32Window()
     m_keyMap[VK_F10] = Fw::KeyF10;
     m_keyMap[VK_F11] = Fw::KeyF11;
     m_keyMap[VK_F12] = Fw::KeyF12;
+    m_keyMap[VK_BROWSER_BACK] = Fw::KeyBrowserBack;
+    m_keyMap[VK_BROWSER_SEARCH] = Fw::KeyBrowserSearch;
+    m_keyMap[VK_BROWSER_HOME] = Fw::KeyBrowserHome;
+    m_keyMap[VK_VOLUME_MUTE] = Fw::KeyVolumeMute;
+    m_keyMap[VK_VOLUME_DOWN] = Fw::KeyVolumeDown;
+    m_keyMap[VK_VOLUME_UP] = Fw::KeyVolumeUp;
+    m_keyMap[VK_MEDIA_NEXT_TRACK] = Fw::KeyMediaNext;
+    m_keyMap[VK_MEDIA_PREV_TRACK] = Fw::KeyMediaPrev;
+    m_keyMap[VK_MEDIA_PLAY_PAUSE] = Fw::KeyMediaPlayPause;
+    m_keyMap[VK_LAUNCH_MEDIA_SELECT] = Fw::KeyLaunchMediaSelect;
 }
 
 void WIN32Window::init()


### PR DESCRIPTION
# Description

Added support for media keys. I need this because my keyboard Logitech K400 plus need to use a Fn key to access to F1-F12 keys, and only media keys can be used with only a keypress.

## Behavior

In the current version you can't use media keys to use as hotkeys in action bars

### **Expected**

Be able to use one single key in my keyboard ashotkey

## Fixes

This is not a bugfix

## Type of change

  - [X] New feature (non-breaking change which adds functionality)


## How Has This Been Tested

After compiling with proposed changes:

  - [X] Test new keys as detected in hotkeys configuration for action bars
  - [X] 30 minutes hunt to verify hotkeys are working
  
**Test Configuration**:

  - Server Version: canary 3.2.0
  - Client: Otclient Redemption v4
  - Operating System: Windows 10 Home

## Checklist

  - [X] My code follows the style guidelines of this project
  - [X] I have performed a self-review of my own code
  - [] I checked the PR checks reports
  - [ ] I have commented my code, particularly in hard-to-understand areas
  - [ ] I have made corresponding changes to the documentation
  - [X] My changes generate no new warnings
  - [ ] I have added tests that prove my fix is effective or that my feature works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for multimedia and browser control keys found on compatible external keyboards, including volume controls (mute, up, down), media playback controls (play/pause, next track, previous track), and web browser navigation buttons (back, search, home).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->