### PR TITLE
Fix vcpkg in ARM CPUs

### DIFF
--- a/Dockerfile.browser
+++ b/Dockerfile.browser
@@ -31,6 +31,7 @@ RUN git clone --filter=blob:none --single-branch --depth 1 https://github.com/em
  && /opt/emsdk/emsdk activate latest
 
 ENV VCPKG_ROOT=/opt/vcpkg
+ENV VCPKG_FORCE_SYSTEM_BINARIES=1
 COPY vcpkg.json /tmp/vcpkg.json
 RUN git clone --filter=blob:none https://github.com/microsoft/vcpkg.git ${VCPKG_ROOT} \
  && cd ${VCPKG_ROOT} \


### PR DESCRIPTION
# Description

The browser Dockerfile was missing the VCPKG_FORCE_SYSTEM_BINARIES env var, which is required for vcpkg to work on ARM CPUs. If it isn’t set, vcpkg reports this error: "Environment variable VCPKG_FORCE_SYSTEM_BINARIES must be set on arm, s390x, ppc64le and riscv platforms."

## Type of change

  - [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested

I ran the `Dockerfile.browser.sh` script on a ARM CPU and it built the client successfully - I opened it in the browser and it was working (although full of visual glitches, but I'm assuming that they're not related to this change and are pre-existing).

The GitHub Action that builds the browser Dockerfile is green on this PR, so I'm assuming it didn't break x86 builds.

**Test Configuration**:

  - Server Version: none
  - Client: latest commit on master
  - Operating System: Mac OS 26.3 (Apple Silicon/ARM)

## Checklist

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [ ] I checked the PR checks reports
  - [ ] I have commented my code, particularly in hard-to-understand areas
  - [ ] I have made corresponding changes to the documentation
  - [x] My changes generate no new warnings
  - [ ] I have added tests that prove my fix is effective or that my feature works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker build configuration with an additional environment variable for the container build process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->