### PR TITLE
improve: allow pkgconfig fallback on Linux

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -125,6 +125,14 @@ add_definitions(-D"BUILD_REVISION=\\\"${BUILD_REVISION}\\\"")
 # *****************************************************************************
 # Packages / Libs
 # *****************************************************************************
+# Before we begin loading packages wholesale, we have to check which package
+# provider is available. Normally, OTClient developers prefer vcpkg.
+# However if that is not available, we can check if PkgConfig is available.
+# PkgConfig is only intended for package maintainers.
+# *****************************************************************************
+if(NOT DEFINED VCPKG_TARGET_TRIPLET)
+  find_package(PkgConfig REQUIRED)
+endif()
 find_package(OpenSSL QUIET)
 find_package(PhysFS REQUIRED)
 find_package(ZLIB REQUIRED)
@@ -224,6 +232,14 @@ else()
     else()
       pkg_check_modules(GLEW REQUIRED IMPORTED_TARGET glew)
       add_library(GLEW::GLEW ALIAS PkgConfig::GLEW)
+# *****************************************************************************
+# GLEW_LIBRARY seems to be missing from PkgConfig::GLEW, so
+# we're gonna declare it with the value of GLEW_LIBRARIES to make the rest
+# of the recipe hold it together.
+# *****************************************************************************
+      if(NOT DEFINED GLEW_LIBRARY AND DEFINED GLEW_LIBRARIES)
+        set(GLEW_LIBRARY "${GLEW_LIBRARIES}")
+      endif()
     endif()
     find_package(LuaJIT REQUIRED)
   else()
@@ -808,7 +824,7 @@ else() # Linux
           $<$<BOOL:${TOGGLE_FRAMEWORK_PROTOBUF}>:${Protobuf_INCLUDE_DIRS}>
           ${GMP_INCLUDE_DIR}
           ${PHYSFS_INCLUDE_DIR}
-          GLEW::GLEW
+          ${GLEW_INCLUDE_DIR}
           ${PARALLEL_HASHMAP_INCLUDE_DIRS}
           ${NLOHMANN_JSON_INCLUDE_DIR}
           ${OPENSSL_INCLUDE_DIR}
@@ -820,7 +836,7 @@ else() # Linux
           ${PHYSFS_LIBRARY}
           ${ZLIB_LIBRARY}
           ${NLOHMANN_JSON_LIBRARY}
-          GLEW::GLEW
+          ${GLEW_LIBRARY}
           ${OPENGL_LIBRARIES}
           ${DirectX_LIBRARY}
           ${DirectX_LIBRARIES}

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -143,7 +143,12 @@ find_package(ZLIB REQUIRED)
 find_package(httplib CONFIG REQUIRED)
 find_package(fmt CONFIG REQUIRED)
 find_package(utf8cpp REQUIRED)
-find_package(unofficial-inih CONFIG REQUIRED)
+if(DEFINED VCPKG_TARGET_TRIPLET)
+  find_package(unofficial-inih CONFIG REQUIRED)
+else()
+  pkg_check_modules(INIReader REQUIRED IMPORTED_TARGET INIReader)
+  add_library(unofficial::inih::inireader ALIAS PkgConfig::INIReader)
+endif()
 find_package(Freetype REQUIRED)
 
 find_path(CPPCODEC_INCLUDE_DIRS "cppcodec/base32_crockford.hpp")
@@ -177,9 +182,30 @@ if(TOGGLE_FRAMEWORK_SOUND)
   if(NOT WASM)
     find_package(OpenAL CONFIG REQUIRED)
   endif()
-  find_package(VorbisFile REQUIRED)
-  find_package(Vorbis CONFIG REQUIRED)
-  find_package(Ogg CONFIG REQUIRED)
+  if(DEFINED VCPKG_TARGET_TRIPLET)
+    find_package(VorbisFile REQUIRED)
+    find_package(Vorbis CONFIG REQUIRED)
+    find_package(Ogg CONFIG REQUIRED)
+  else()
+    pkg_check_modules(VORBISFILE REQUIRED vorbisfile)
+    add_library(Vorbis::vorbisfile INTERFACE IMPORTED)
+    set_target_properties(Vorbis::vorbisfile PROPERTIES
+      INTERFACE_INCLUDE_DIRECTORIES "${VORBISFILE_INCLUDE_DIRS}"
+      INTERFACE_LINK_LIBRARIES "${VORBISFILE_LIBRARIES}"
+    )
+    pkg_check_modules(VORBIS REQUIRED vorbis)
+    add_library(Vorbis::vorbis INTERFACE IMPORTED)
+    set_target_properties(Vorbis::vorbis PROPERTIES
+      INTERFACE_INCLUDE_DIRECTORIES "${VORBIS_INCLUDE_DIRS}"
+      INTERFACE_LINK_LIBRARIES "${VORBIS_LIBRARIES}"
+    )
+    pkg_check_modules(OGG REQUIRED ogg)
+    add_library(Ogg::ogg INTERFACE IMPORTED)
+    set_target_properties(Ogg::ogg PROPERTIES
+      INTERFACE_INCLUDE_DIRECTORIES "${OGG_INCLUDE_DIRS}"
+      INTERFACE_LINK_LIBRARIES "${OGG_LIBRARIES}"
+    )
+  endif()
 endif()
 if(ANDROID)
   set(LUA_LIBRARY ${LUA_LIBRARY} ${Android_LIBRARIES}/liblua.a)
@@ -193,7 +219,12 @@ if(ANDROID)
 else()
   if(NOT WASM)
     find_package(OpenGL REQUIRED)
-    find_package(GLEW REQUIRED)
+    if(DEFINED VCPKG_TARGET_TRIPLET)
+      find_package(GLEW REQUIRED)
+    else()
+      pkg_check_modules(GLEW REQUIRED IMPORTED_TARGET glew)
+      add_library(GLEW::GLEW ALIAS PkgConfig::GLEW)
+    endif()
     find_package(LuaJIT REQUIRED)
   else()
     set(LUA_LIBRARY ${LUA_LIBRARY} ${CMAKE_SOURCE_DIR}/browser/include/lua51/liblua.a)
@@ -777,7 +808,7 @@ else() # Linux
           $<$<BOOL:${TOGGLE_FRAMEWORK_PROTOBUF}>:${Protobuf_INCLUDE_DIRS}>
           ${GMP_INCLUDE_DIR}
           ${PHYSFS_INCLUDE_DIR}
-          ${GLEW_INCLUDE_DIR}
+          GLEW::GLEW
           ${PARALLEL_HASHMAP_INCLUDE_DIRS}
           ${NLOHMANN_JSON_INCLUDE_DIR}
           ${OPENSSL_INCLUDE_DIR}
@@ -789,7 +820,7 @@ else() # Linux
           ${PHYSFS_LIBRARY}
           ${ZLIB_LIBRARY}
           ${NLOHMANN_JSON_LIBRARY}
-          ${GLEW_LIBRARY}
+          GLEW::GLEW
           ${OPENGL_LIBRARIES}
           ${DirectX_LIBRARY}
           ${DirectX_LIBRARIES}


### PR DESCRIPTION
# Description

Summary:
This PR concerns the consumption of the following libraries:
- INIReader (provided by inih as C++ bindings)
- VorbisFile (provided by Vorbis)
- Vorbis
- OGG
- GLEW

On most Linux distributions these libraries are provided without CMake package configuration files, which means that on Linux, projects normally consume them via pkgconfig. vcpkg is the only package manager I know that provides CMake package configuration files for these libraries and with OTClient's extensive reliance on vcpkg we can now see why OTClient is written with the assumption that these files exist. This assumption falls apart on pretty much every Linux distribution when vcpkg is not used.

This PR introduces detection of vcpkg triplets in places where these libraries are loaded by CMake. The proposed changes accomodate both scenarios: when vcpkg is present, and when it isn't. That way we should not encounter a situation like in #1508 where CICD passes the build, but the build fails on a user's machine.

Issues fixed:
- #1543
- #1507, but this time both vcpkg and pkgconfig are accomodated instead of making only one of them work

Motivation:
I want to package OTClient for Gentoo in my overlay: https://github.com/grepwood/timberlay

Context:
I can provide ebuilds for dependencies that are missing from Gentoo's main repository. But changes in affected libraries (dev-libs/inih, media-libs/libvorbis, media-libs/libogg, media-libs/glew) that would render this PR unnecessary are not welcome by maintainers of Gentoo Linux. The general argument was that CMake is not used to build them, but upon inspection I found out more substantial reasons to support that decision:
- CMake configuration files for these packages are out of date, they fall apart with CMake 4.1.4
- those files don't fall apart with CMake included with MSVC 2019, which probably means those files are only there to allow vcpkg to package them for Windows

Dependencies:
On systems with vcpkg, nothing changes.
On systems without vcpkg, these libraries need to be installed through the system's package manager. Here is an example:
| Distro | Package names |
|--------|---------------|
| Gentoo | - dev-libs/inih<br> - media-libs/libvorbis<br> - media-libs/libogg<br> - media-libs/glew |
| Debian | - libinih-dev<br> - libvorbis-dev<br> - libogg-dev<br> - libglew-dev |
| RHEL   | - inih-devel<br> - libvorbis-devel<br> - libogg-devel<br> - glew-devel |

## Behavior

### **Actual**

OTClient's CMake setup expects that these libraries always ship CMake package configuration files which is not true on Linux distributions in general. This will happen on a system without vcpkg:
```
-- The C compiler identification is GNU 15.2.1
-- The CXX compiler identification is GNU 15.2.1
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /usr/bin/cc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /usr/bin/c++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Enabled: ipo
-- Found Protobuf: /usr/lib64/libprotobuf.so (found version "6.31.1")
-- Found Threads: TRUE
-- Found Protobuf Compiler: /usr/bin/protoc
-- Build type: 
-- Build commit: 
-- Build revision: 
-- Found ZLIB: /usr/lib64/libz.so (found version "1.3.1")
-- Looking for C++ include parallel_hashmap/phmap.h
-- Looking for C++ include parallel_hashmap/phmap.h - found
-- Looking for C++ include parallel_hashmap/btree.h
-- Looking for C++ include parallel_hashmap/btree.h - found
-- Looking for lzma_auto_decoder in /usr/lib64/liblzma.so
-- Looking for lzma_auto_decoder in /usr/lib64/liblzma.so - found
-- Looking for lzma_easy_encoder in /usr/lib64/liblzma.so
-- Looking for lzma_easy_encoder in /usr/lib64/liblzma.so - found
-- Looking for lzma_lzma_preset in /usr/lib64/liblzma.so
-- Looking for lzma_lzma_preset in /usr/lib64/liblzma.so - found
-- Found LibLZMA: /usr/lib64/liblzma.so (found version "5.8.2")
-- Found nlohmann_json: /usr/share/cmake/nlohmann_json/nlohmann_jsonConfig.cmake (found version "3.12.0")
-- Found asio: /usr/include
-- Found OpenSSL: /usr/lib64/libcrypto.so (found suitable version "3.5.5", minimum required is "3.0.0") found components: Crypto SSL
-- Found httplib: /usr/lib64/libcpp-httplib.so.0.26.0 (found version "0.26.0")
CMake Error at src/CMakeLists.txt:146 (find_package):
  Could not find a package configuration file provided by "unofficial-inih"
  with any of the following names:

    unofficial-inihConfig.cmake
    unofficial-inih-config.cmake

  Add the installation prefix of "unofficial-inih" to CMAKE_PREFIX_PATH or
  set "unofficial-inih_DIR" to a directory containing one of the above files.
  If "unofficial-inih" provides a separate development package or SDK, be
  sure it has been installed.


-- Configuring incomplete, errors occurred!
```

The same problem occurs with vorbis, vorbisfile, ogg and glew.

### **Expected**

After applying this patch, source configuration should go down like this:
```
-- The C compiler identification is GNU 15.2.1
-- The CXX compiler identification is GNU 15.2.1
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /usr/bin/cc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /usr/bin/c++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Enabled: ipo
-- Found Protobuf: /usr/lib64/libprotobuf.so (found version "6.31.1")
-- Found Threads: TRUE
-- Found Protobuf Compiler: /usr/bin/protoc
-- Build type: 
-- Build commit: 
-- Build revision: 
-- Found ZLIB: /usr/lib64/libz.so (found version "1.3.1")
-- Looking for C++ include parallel_hashmap/phmap.h
-- Looking for C++ include parallel_hashmap/phmap.h - found
-- Looking for C++ include parallel_hashmap/btree.h
-- Looking for C++ include parallel_hashmap/btree.h - found
-- Looking for lzma_auto_decoder in /usr/lib64/liblzma.so
-- Looking for lzma_auto_decoder in /usr/lib64/liblzma.so - found
-- Looking for lzma_easy_encoder in /usr/lib64/liblzma.so
-- Looking for lzma_easy_encoder in /usr/lib64/liblzma.so - found
-- Looking for lzma_lzma_preset in /usr/lib64/liblzma.so
-- Looking for lzma_lzma_preset in /usr/lib64/liblzma.so - found
-- Found LibLZMA: /usr/lib64/liblzma.so (found version "5.8.2")
-- Found nlohmann_json: /usr/share/cmake/nlohmann_json/nlohmann_jsonConfig.cmake (found version "3.12.0")
-- Found asio: /usr/include
-- Found OpenSSL: /usr/lib64/libcrypto.so (found suitable version "3.5.5", minimum required is "3.0.0") found components: Crypto SSL
-- Found httplib: /usr/lib64/libcpp-httplib.so.0.26.0 (found version "0.26.0")
-- Checking for module 'INIReader'
--   Found INIReader, version 62
-- Found Freetype: /usr/lib64/libfreetype.so (found version "2.14.1")
-- Found X11: /usr/include
-- Looking for XOpenDisplay in /usr/lib64/libX11.so;/usr/lib64/libXext.so
-- Looking for XOpenDisplay in /usr/lib64/libX11.so;/usr/lib64/libXext.so - found
-- Looking for gethostbyname
-- Looking for gethostbyname - found
-- Looking for connect
-- Looking for connect - found
-- Looking for remove
-- Looking for remove - found
-- Looking for shmat
-- Looking for shmat - found
-- Looking for IceConnectionNumber in ICE
-- Looking for IceConnectionNumber in ICE - found
-- Disabled: Discord Rich Presence
-- Checking for module 'vorbisfile'
--   Found vorbisfile, version 1.3.7
-- Checking for module 'vorbis'
--   Found vorbis, version 1.3.7
-- Checking for module 'ogg'
--   Found ogg, version 1.3.6
CMake Warning (dev) at /usr/share/cmake/Modules/FindPackageHandleStandardArgs.cmake:430 (message):
  The package name passed to find_package_handle_standard_args() (X11) does
  not match the name of the calling package (OpenGL).  This can lead to
  problems in calling code that expects find_package() result variables
  (e.g., `_FOUND`) to follow a certain pattern.
Call Stack (most recent call first):
  /usr/share/cmake/Modules/FindX11.cmake:684 (find_package_handle_standard_args)
  cmake/FindOpenGL.cmake:128 (INCLUDE)
  src/CMakeLists.txt:221 (find_package)
This warning is for project developers.  Use -Wno-dev to suppress it.

-- Checking for module 'glew'
--   Found glew, version 2.2.0
-- Found LuaJIT: /usr/lib64/libluajit-5.1.so
-- Use precompiled header: ON
-- Enabled: Build unity for speed up compilation
-- Disabled: asan
-- Disabled: DEBUG LOG
-- Disabled: Build tests
-- Configuring done (5.8s)
-- Generating done (0.1s)
-- Build files have been written to: /home/mdec/git/grepwood/otclient/build
```

## Fixes

- #1543
- #1507, but this time both vcpkg and pkgconfig are accomodated instead of making only one of them work

## Type of change

Please delete options that are not relevant.

  - [X] Bug fix (non-breaking change which fixes an issue)
  - [ ] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [?] This change requires a documentation update

Documentation update - not sure. This change is intended to accomodate package maintainers, which should rely on the distro's package manager instead of vcpkg. These changes do not break the intended way of compiling with vcpkg, but they do offer ways to compile without it as a fallback.

If documentation change is deemed necessary, then the list of packages from the example should be resolved per supported distro and included in the docs. Ubuntu should have the same packages as Debian.

## How Has This Been Tested

In https://github.com/grepwood/timberlay/commit/58d26bd6bd33215907fd637bd0b80ab726301e16 I have added OTClient 4.0 with a similar patch https://github.com/grepwood/timberlay/commit/58d26bd6bd33215907fd637bd0b80ab726301e16#diff-45871ba1da40e367a7028597e8c71485b94db0041b10bc69542667a6286d7239 that just isn't up to date as per the master branch of OTClient, due to OTClient now pulling in FreeType. Building the package passes - but the `src_install` phase will differ in the future, because OTClient requires more for running than just the binary.

**Test Configuration**:

  - Server Version: None tried
  - Client: 4.0
  - Operating System: Gentoo Linux

## Checklist

  - [X] My code follows the style guidelines of this project
  - [X] I have performed a self-review of my own code
  - [ ] I checked the PR checks reports
  - [ ] I have commented my code, particularly in hard-to-understand areas
  - [ ] I have made corresponding changes to the documentation
  - [X] My changes generate no new warnings
  - [ ] I have added tests that prove my fix is effective or that my feature works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved build configuration to better handle different dependency providers and package managers, enabling conditional resolution of media and graphics libraries and the INI reader. This increases compatibility and robustness across platforms (including non-WASM/non-Android builds), reducing manual setup and improving build success in diverse development environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->