### PR TITLE
fix(forge): convergence item list not refreshing and negative gold guard

### DIFF
--- a/modules/game_forge/game_forge.lua
+++ b/modules/game_forge/game_forge.lua
@@ -2,6 +2,7 @@ ForgeController = Controller:new()
 ForgeButton = nil
 
 local cloneValue = Helpers.cloneValue
+local replaceTableContents = Helpers.replaceTableContents
 local normalizeClassPriceEntries = Helpers.normalizeClassPriceEntries
 local normalizeTierPriceEntries = Helpers.normalizeTierPriceEntries
 -- Don't cache formatHistoryDate as a local since it may be updated
@@ -63,7 +64,7 @@ local function resetInfo()
     ForgeController.transfer.isConvergence = false
     ForgeController.transfer.title = "Transfer Requirements"
     ForgeController.transfer.dustLabel = ForgeController.transfer.dust
-    ForgeController.transfer.currentList = cloneValue(ForgeController.transfer.items)
+    replaceTableContents(ForgeController.transfer.currentList, ForgeController.transfer.items)
     ForgeController.fusion.title = "Further Items Needed For Fusion"
     ForgeController.fusion.selected = cloneValue(ForgeController.baseSelected)
     ForgeController.fusion.selectedTarget = cloneValue(ForgeController.baseSelected)
@@ -73,7 +74,7 @@ local function resetInfo()
     ForgeController.fusion.chanceImprovedChecked = false
     ForgeController.fusion.reduceTierLossChecked = false
     ForgeController.fusion.dustLabel = ForgeController.fusion.dust
-    ForgeController.fusion.currentList = cloneValue(ForgeController.fusion.items)
+    replaceTableContents(ForgeController.fusion.currentList, ForgeController.fusion.items)
     ForgeController.showResult = false
     ForgeController.showBonus = false
     ForgeController.result = cloneValue(Helpers.baseResult)
@@ -259,6 +260,11 @@ function ForgeController:getPrice(prices, itemId, currentTier, isConvergence, is
             end
         end
     end
+
+    -- Guard against negative prices from server data (e.g. uint64 overflow in pushInteger).
+    -- A zero price will block forgeAction() via the rawPrice <= 0 check, which is intentional:
+    -- the client should not allow forging when the server sends invalid pricing.
+    if price < 0 then price = 0 end
 
     self.rawPrice = price
     self.formattedPrice = comma_value(price)
@@ -789,29 +795,30 @@ function ForgeController:toggleConvergence(isTransfer)
     ForgeController.formattedPrice = "???"
     ForgeController.rawPrice = 0
 
+    local source = data.isConvergence and data.convergenceItems or data.items
+
     if isTransfer then
         data.canTransfer = false
         if not data.isConvergence then
-            data.currentList = cloneValue(data.items)
             data.title = "Transfer Requirements"
             data.dustLabel = data.dust
         else
-            data.currentList = cloneValue(data.convergenceItems)
             data.title = "Convergence Transfer Requirements"
             data.dustLabel = data.convergenceDust
         end
     else
         data.canFusion = false
         if not data.isConvergence then
-            data.currentList = cloneValue(data.items)
             data.title = "Further Items Needed For Fusion"
             data.dustLabel = data.dust
         else
             data.dustLabel = data.convergenceDust
-            data.currentList = cloneValue(data.convergenceItems)
             data.title = "Further Items Needed For Convergence Fusion"
         end
     end
+
+    -- Replace contents in-place to preserve the table reference for reactive UI
+    replaceTableContents(data.currentList, source)
 end
 
 -- TRANSFER MENU
@@ -890,7 +897,7 @@ function onOpenForge(data)
     local items = cloneValue(data.fusionItems or {})
     local fusionItems = handleFusionItems(items)
     ForgeController.fusion.items = fusionItems
-    ForgeController.fusion.currentList = cloneValue(fusionItems)
+    replaceTableContents(ForgeController.fusion.currentList, fusionItems)
     local convergenceFusion = cloneValue(data.convergenceFusion or {})
     local _, convergenceItemsBySlot = handleParseConvergenceFusionItems(convergenceFusion)
     ForgeController.fusion.convergenceItems = convergenceItemsBySlot
@@ -900,7 +907,7 @@ function onOpenForge(data)
     local transfers = cloneValue(data.transfers or {})
     local transferItems = handleTransferItems(transfers)
     ForgeController.transfer.items = transferItems
-    ForgeController.transfer.currentList = cloneValue(transferItems)
+    replaceTableContents(ForgeController.transfer.currentList, transferItems)
 
     local convergenceTransfers = cloneValue(data.convergenceTransfers or {})
     local convergenceTransferItems = handleTransferItems(convergenceTransfers)

--- a/modules/game_forge/game_forge_helpers.lua
+++ b/modules/game_forge/game_forge_helpers.lua
@@ -1,5 +1,25 @@
 Helpers = {}
 
+-- Replaces table contents in-place to preserve the reference for reactive UI bindings.
+-- Recursively preserves sub-table references (e.g. transfer.currentList.donors)
+-- when both target and source have a table at the same key.
+function Helpers.replaceTableContents(target, source)
+    local sourceKeys = {}
+    for k in pairs(source) do sourceKeys[k] = true end
+
+    for k in pairs(target) do
+        if not sourceKeys[k] then target[k] = nil end
+    end
+
+    for k, v in pairs(source) do
+        if type(v) == 'table' and type(target[k]) == 'table' then
+            Helpers.replaceTableContents(target[k], v)
+        else
+            target[k] = Helpers.cloneValue(v)
+        end
+    end
+end
+
 function Helpers.cloneValue(value)
     if type(value) == 'table' then
         if table and type(table.recursivecopy) == 'function' then


### PR DESCRIPTION
## Summary

Fixes the forge convergence checkbox not updating the item list (#1665), and adds a guard against negative gold values displayed for high-tier convergence pricing.

## Fixes #1665

### Item list not refreshing

`toggleConvergence()` replaced `data.currentList` with a new cloned table on every toggle. The reactive UI binding (`*for` directive in `game_forge.html`) tracks the original table reference -- assigning a new table breaks the binding and the list doesn't re-render. Users had to switch tabs and come back to see the updated items.

Fix: `replaceTableContents()` helper that clears and repopulates the existing table in-place, preserving the reference the UI is bound to.

### Negative gold on high tiers

The convergence price comes from the server as `uint64` (`protocolgameparse.cpp:1996`). If the server sends a value that overflows when converted to a Lua number via `pushInteger`, or if the server-side calculation produces an invalid price for certain tiers (e.g. tier 5→6), the client displayed it as-is -- including negative values.

Fix: clamp `price` to 0 in `getPrice()` before assigning to `rawPrice` / `formattedPrice`. The root cause for specific tiers is likely server-side (canary), but the client should never display a negative cost.

## Files changed

- **`game_forge_helpers.lua`** -- new `Helpers.replaceTableContents(target, source)` helper
- **`game_forge.lua`** -- `toggleConvergence()` uses in-place replacement instead of table reassignment, `getPrice()` clamps negative values

## Test plan

- [ ] Open forge, click Convergence checkbox -- item list updates immediately without switching tabs
- [ ] Toggle convergence off -- list reverts to normal items immediately
- [ ] Repeat for both Fusion and Transfer tabs
- [ ] Tier 5→6 convergence fusion no longer shows negative gold
- [ ] Normal (non-convergence) fusion/transfer pricing unaffected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where item prices could become negative; prices are now clamped to a minimum of zero.

* **Refactor**
  * Internal list updates now modify existing lists in-place (instead of replacing them), improving UI stability and ensuring list views and bindings remain consistent when switching modes or refreshing content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->