### PR TITLE
fix: CPPHTTPLIB_OPENSSL_SUPPORT might be redeclared

### DIFF
--- a/src/framework/net/httplogin.h
+++ b/src/framework/net/httplogin.h
@@ -22,7 +22,9 @@
 
 #pragma once
 
-#define CPPHTTPLIB_OPENSSL_SUPPORT
+#ifndef CPPHTTPLIB_OPENSSL_SUPPORT
+#    define CPPHTTPLIB_OPENSSL_SUPPORT
+#endif
 #include <framework/luaengine/luaobject.h>
 #include <httplib.h>
 


### PR DESCRIPTION
# Description

Summary:
This PR addresses a redefinition of `CPPHTTPLIB_OPENSSL_SUPPORT`. It's just a compiler warning fix.

Motivation:
I want to fix everything I've encountered while packaging OTClient for Gentoo Linux.

Context:
This PR makes Linux builds produce less noisy output.

Dependencies:
None changed.

## Behavior

### **Actual**

```
In file included from /var/tmp/portage/games-rpg/otclient-4.0/work/otclient-4.0/src/framework/net/httplogin.cpp:23,
                 from /var/tmp/portage/games-rpg/otclient-4.0/work/otclient-4.0_build/src/CMakeFiles/otclient_core.dir/Unity/unity_3_cxx.cxx:13:
/var/tmp/portage/games-rpg/otclient-4.0/work/otclient-4.0/src/framework/net/httplogin.h:25:9: warning: ‘CPPHTTPLIB_OPENSSL_SUPPORT’ redefined
   25 | #define CPPHTTPLIB_OPENSSL_SUPPORT
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~
<command-line>: note: this is the location of the previous definition
In file included from /var/tmp/portage/games-rpg/otclient-4.0/work/otclient-4.0/src/framework/luafunctions.cpp:61,
                 from /var/tmp/portage/games-rpg/otclient-4.0/work/otclient-4.0_build/src/CMakeFiles/otclient_core.dir/Unity/unity_2_cxx.cxx:19:
/var/tmp/portage/games-rpg/otclient-4.0/work/otclient-4.0/src/framework/net/httplogin.h:25:9: warning: ‘CPPHTTPLIB_OPENSSL_SUPPORT’ redefined
   25 | #define CPPHTTPLIB_OPENSSL_SUPPORT
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~
<command-line>: note: this is the location of the previous definition
```

### **Expected**

We shouldn't redefine preprocessor variables.

## Fixes

There is no issue filed for this.

## Type of change

Please delete options that are not relevant.

  - [X] Bug fix (non-breaking change which fixes an issue)
  - [ ] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [ ] This change requires a documentation update

## How Has This Been Tested

I compiled OTClient with and without this change. With the change, the warning is no longer emitted.

## Checklist

  - [X] My code follows the style guidelines of this project
  - [X] I have performed a self-review of my own code
  - [X] I checked the PR checks reports
  - [ ] I have commented my code, particularly in hard-to-understand areas
  - [ ] I have made corresponding changes to the documentation
  - [X] My changes generate no new warnings
  - [ ] I have added tests that prove my fix is effective or that my feature works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved internal code configuration handling to prevent potential conflicts with preprocessor definitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->