### PR TITLE
fix: typo thingTye -> thingType

### DIFF
--- a/src/client/attachedeffect.cpp
+++ b/src/client/attachedeffect.cpp
@@ -186,25 +186,25 @@ int AttachedEffect::getCurrentAnimationPhase()
         return m_frame;
     }
 
-    const auto thingTye = getThingType();
+    const auto thingType = getThingType();
 
-    const auto* animator = thingTye->getIdleAnimator();
-    if (!animator && thingTye->isAnimateAlways())
-        animator = thingTye->getAnimator();
+    const auto* animator = thingType->getIdleAnimator();
+    if (!animator && thingType->isAnimateAlways())
+        animator = thingType->getAnimator();
 
     if (animator)
         return animator->getPhaseAt(m_animationTimer, getSpeed());
 
-    if (thingTye->isEffect()) {
-        const int lastPhase = thingTye->getAnimationPhases() - 1;
+    if (thingType->isEffect()) {
+        const int lastPhase = thingType->getAnimationPhases() - 1;
         const int phase = std::min<int>(static_cast<int>(m_animationTimer.ticksElapsed() / (g_gameConfig.getEffectTicksPerFrame() / getSpeed())), lastPhase);
         if (phase == lastPhase) m_animationTimer.restart();
         return phase;
     }
 
-    if (thingTye->isCreature() && thingTye->isAnimateAlways()) {
-        const int ticksPerFrame = std::round(1000 / thingTye->getAnimationPhases()) / getSpeed();
-        return (g_clock.millis() % (static_cast<long long>(ticksPerFrame) * thingTye->getAnimationPhases())) / ticksPerFrame;
+    if (thingType->isCreature() && thingType->isAnimateAlways()) {
+        const int ticksPerFrame = std::round(1000 / thingType->getAnimationPhases()) / getSpeed();
+        return (g_clock.millis() % (static_cast<long long>(ticksPerFrame) * thingType->getAnimationPhases())) / ticksPerFrame;
     }
 
     return 0;


### PR DESCRIPTION
Hey folks!

Tiny cleanup: this just renames the local variable thingTye to thingType in AttachedEffect::getCurrentAnimationPhase() so it’s easier to read/search and avoids spreading the typo further.

No behavior change intended.

Thanks!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected variable naming in animation phase calculation logic to improve code reliability.

* **Style**
  * Enhanced code formatting consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->