### PR TITLE
fix: avoid animation phase edge-case crashes

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -491,6 +491,8 @@ if(MSVC)
           _WIN32_WINNT=0x0600
   )
 
+  target_compile_definitions(otclient_core PRIVATE CRASH_HANDLER)
+
   target_compile_options(otclient_core PUBLIC /MP /FS /Zf /EHsc /bigobj)
 
   if(CMAKE_BUILD_TYPE STREQUAL "Debug")

--- a/src/client/attachedeffect.cpp
+++ b/src/client/attachedeffect.cpp
@@ -187,6 +187,7 @@ int AttachedEffect::getCurrentAnimationPhase()
     }
 
     const auto thingTye = getThingType();
+    if (!thingTye) return 0;
 
     const auto* animator = thingTye->getIdleAnimator();
     if (!animator && thingTye->isAnimateAlways())
@@ -196,15 +197,28 @@ int AttachedEffect::getCurrentAnimationPhase()
         return animator->getPhaseAt(m_animationTimer, getSpeed());
 
     if (thingTye->isEffect()) {
-        const int lastPhase = thingTye->getAnimationPhases() - 1;
-        const int phase = std::min<int>(static_cast<int>(m_animationTimer.ticksElapsed() / (g_gameConfig.getEffectTicksPerFrame() / getSpeed())), lastPhase);
+        const int animationPhases = thingTye->getAnimationPhases();
+        const int speed = getSpeed();
+        if (animationPhases <= 0 || speed <= 0) return 0;
+
+        const int lastPhase = animationPhases - 1;
+        const int effectTicksPerFrame = g_gameConfig.getEffectTicksPerFrame();
+        const int ticksPerFrame = std::max<int>(1, effectTicksPerFrame / speed);
+        const int phase = std::min<int>(static_cast<int>(m_animationTimer.ticksElapsed() / ticksPerFrame), lastPhase);
         if (phase == lastPhase) m_animationTimer.restart();
         return phase;
     }
 
     if (thingTye->isCreature() && thingTye->isAnimateAlways()) {
-        const int ticksPerFrame = std::round(1000 / thingTye->getAnimationPhases()) / getSpeed();
-        return (g_clock.millis() % (static_cast<long long>(ticksPerFrame) * thingTye->getAnimationPhases())) / ticksPerFrame;
+        const int animationPhases = thingTye->getAnimationPhases();
+        const int speed = getSpeed();
+        if (animationPhases <= 0 || speed <= 0) return 0;
+
+        const int ticksPerFrame = std::max<int>(1, static_cast<int>(std::round((1000.0 / animationPhases) / speed)));
+        const long long animationPeriod = static_cast<long long>(ticksPerFrame) * animationPhases;
+        if (animationPeriod <= 0) return 0;
+
+        return (g_clock.millis() % animationPeriod) / ticksPerFrame;
     }
 
     return 0;

--- a/src/client/attachedeffect.cpp
+++ b/src/client/attachedeffect.cpp
@@ -186,39 +186,39 @@ int AttachedEffect::getCurrentAnimationPhase()
         return m_frame;
     }
 
-    const auto thingTye = getThingType();
-    if (!thingTye) return 0;
+    const auto thingType = getThingType();
+    if (!thingType) return 0;
 
-    const auto* animator = thingTye->getIdleAnimator();
-    if (!animator && thingTye->isAnimateAlways())
-        animator = thingTye->getAnimator();
+    const auto* animator = thingType->getIdleAnimator();
+    if (!animator && thingType->isAnimateAlways())
+        animator = thingType->getAnimator();
 
     if (animator)
         return animator->getPhaseAt(m_animationTimer, getSpeed());
 
-    if (thingTye->isEffect()) {
-        const int animationPhases = thingTye->getAnimationPhases();
-        const int speed = getSpeed();
-        if (animationPhases <= 0 || speed <= 0) return 0;
+    if (thingType->isEffect()) {
+        const int animationPhases = thingType->getAnimationPhases();
+        const float speed = getSpeed();
+        if (animationPhases <= 0 || speed <= 0.f) return 0;
 
         const int lastPhase = animationPhases - 1;
         const int effectTicksPerFrame = g_gameConfig.getEffectTicksPerFrame();
-        const int ticksPerFrame = std::max<int>(1, effectTicksPerFrame / speed);
+        const int ticksPerFrame = std::max<int>(1, static_cast<int>(effectTicksPerFrame / speed));
         const int phase = std::min<int>(static_cast<int>(m_animationTimer.ticksElapsed() / ticksPerFrame), lastPhase);
         if (phase == lastPhase) m_animationTimer.restart();
         return phase;
     }
 
-    if (thingTye->isCreature() && thingTye->isAnimateAlways()) {
-        const int animationPhases = thingTye->getAnimationPhases();
-        const int speed = getSpeed();
-        if (animationPhases <= 0 || speed <= 0) return 0;
+    if (thingType->isCreature() && thingType->isAnimateAlways()) {
+        const int animationPhases = thingType->getAnimationPhases();
+        const float speed = getSpeed();
+        if (animationPhases <= 0 || speed <= 0.f) return 0;
 
         const int ticksPerFrame = std::max<int>(1, static_cast<int>(std::round((1000.0 / animationPhases) / speed)));
         const long long animationPeriod = static_cast<long long>(ticksPerFrame) * animationPhases;
         if (animationPeriod <= 0) return 0;
 
-        return (g_clock.millis() % animationPeriod) / ticksPerFrame;
+        return static_cast<int>((g_clock.millis() % animationPeriod) / ticksPerFrame);
     }
 
     return 0;

--- a/src/client/creature.cpp
+++ b/src/client/creature.cpp
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * Copyright (c) 2010-2026 OTClient <https://github.com/edubart/otclient>
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -1190,6 +1190,7 @@ uint16_t Creature::getCurrentAnimationPhase(const bool mount)
     if (!canAnimate()) return 0;
 
     const auto thingType = mount ? getMountThingType() : getThingType();
+    if (!thingType) return 0;
 
     if (const auto idleAnimator = thingType->getIdleAnimator()) {
         if (m_walkAnimationPhase == 0) return idleAnimator->getPhase();
@@ -1197,8 +1198,14 @@ uint16_t Creature::getCurrentAnimationPhase(const bool mount)
     }
 
     if (thingType->isAnimateAlways()) {
-        const int ticksPerFrame = std::round(1000 / thingType->getAnimationPhases());
-        return (g_clock.millis() % (static_cast<long long>(ticksPerFrame) * thingType->getAnimationPhases())) / ticksPerFrame;
+        const int animationPhases = thingType->getAnimationPhases();
+        if (animationPhases <= 0) return 0;
+
+        const int ticksPerFrame = std::max<int>(1, static_cast<int>(std::round(1000.0 / animationPhases)));
+        const long long animationPeriod = static_cast<long long>(ticksPerFrame) * animationPhases;
+        if (animationPeriod <= 0) return 0;
+
+        return static_cast<uint16_t>((g_clock.millis() % animationPeriod) / ticksPerFrame);
     }
 
     return isDisabledWalkAnimation() ? 0 : m_walkAnimationPhase;

--- a/src/client/paperdoll.cpp
+++ b/src/client/paperdoll.cpp
@@ -118,8 +118,8 @@ int Paperdoll::getCurrentAnimationPhase()
 
     if (m_thingType->isCreature() && m_thingType->isAnimateAlways()) {
         const int animationPhases = m_thingType->getAnimationPhases();
-        const int speed = getSpeed();
-        if (animationPhases <= 0 || speed <= 0) return 0;
+        const float speed = getSpeed();
+        if (animationPhases <= 0 || speed <= 0.f) return 0;
 
         const int ticksPerFrame = std::max<int>(1, static_cast<int>(std::round((1000.0 / animationPhases) / speed)));
         const long long animationPeriod = static_cast<long long>(ticksPerFrame) * animationPhases;

--- a/src/client/paperdoll.cpp
+++ b/src/client/paperdoll.cpp
@@ -106,6 +106,9 @@ void Paperdoll::drawLight(const Point& dest, bool mount, LightView* lightView) {
 
 int Paperdoll::getCurrentAnimationPhase()
 {
+    if (!m_thingType)
+        return 0;
+
     const auto* animator = m_thingType->getIdleAnimator();
     if (!animator && m_thingType->isAnimateAlways())
         animator = m_thingType->getAnimator();
@@ -114,8 +117,15 @@ int Paperdoll::getCurrentAnimationPhase()
         return animator->getPhaseAt(m_animationTimer, getSpeed());
 
     if (m_thingType->isCreature() && m_thingType->isAnimateAlways()) {
-        const int ticksPerFrame = std::round(1000 / m_thingType->getAnimationPhases()) / getSpeed();
-        return (g_clock.millis() % (static_cast<long long>(ticksPerFrame) * m_thingType->getAnimationPhases())) / ticksPerFrame;
+        const int animationPhases = m_thingType->getAnimationPhases();
+        const int speed = getSpeed();
+        if (animationPhases <= 0 || speed <= 0) return 0;
+
+        const int ticksPerFrame = std::max<int>(1, static_cast<int>(std::round((1000.0 / animationPhases) / speed)));
+        const long long animationPeriod = static_cast<long long>(ticksPerFrame) * animationPhases;
+        if (animationPeriod <= 0) return 0;
+
+        return static_cast<int>((g_clock.millis() % animationPeriod) / ticksPerFrame);
     }
 
     return 0;


### PR DESCRIPTION
Hey folks!

This is a small safety pass to avoid a couple of nasty edge cases that can crash the client when assets/thing types are incomplete or in a weird state.

- Guard null ThingType* before using it
- Guard getAnimationPhases() / getSpeed() against 0 to avoid divide-by-zero
- Clamp computed ticksPerFrame to at least 1
- Enable CRASH_HANDLER for MSVC builds so we get crashreport.log on Windows

No functional changes intended beyond not crashing in those scenarios.

Cheers!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added crash handler support for improved stability and error recovery

* **Bug Fixes**
  * Made animation phase logic robust with null-safety checks to avoid crashes
  * Hardened animation timing calculations to prevent invalid timing, division/modulo issues, and rendering glitches
<!-- end of auto-generated comment: release notes by coderabbit.ai -->