### PR TITLE
fix: encryption system crashes and data corruption when ENABLE_ENCRYPTION=1

### DIFF
--- a/src/framework/core/filestream.cpp
+++ b/src/framework/core/filestream.cpp
@@ -87,15 +87,12 @@ void FileStream::cache(bool
 
 #if ENABLE_ENCRYPTION == 1
         if (useEnc) {
-            if (m_data.size() >= std::string(ENCRYPTION_HEADER).size() &&
-                std::memcmp(m_data.data(), ENCRYPTION_HEADER, std::string(ENCRYPTION_HEADER).size()) == 0) {
-                m_data.erase(m_data.begin(), m_data.begin() + std::string(ENCRYPTION_HEADER).size());
+            const std::string encHeader(ENCRYPTION_HEADER);
+            if (m_data.size() >= encHeader.size() &&
+                std::memcmp(m_data.data(), encHeader.data(), encHeader.size()) == 0) {
+                m_data.erase(m_data.begin(), m_data.begin() + encHeader.size());
+                ResourceManager::decrypt(m_data.data(), m_data.size());
             }
-
-            uint8_t* decryptedData = ResourceManager::decrypt(m_data.data(), m_data.size());
-            m_data.resize(size - std::string(ENCRYPTION_HEADER).size());
-            std::memcmp(m_data.data(), decryptedData, m_data.size());
-            delete[] decryptedData;
         }
 #endif
         PHYSFS_close(m_fileHandle);

--- a/src/framework/core/logger.cpp
+++ b/src/framework/core/logger.cpp
@@ -38,11 +38,7 @@ Logger g_logger;
 namespace
 {
     constexpr std::string_view s_logPrefixes[] = { "", "", "", "WARNING: ", "ERROR: ", "FATAL ERROR: " };
-#if ENABLE_ENCRYPTION == 1
-    bool s_ignoreLogs = true;
-#else
     bool s_ignoreLogs = false;
-#endif
 }
 
 void Logger::log(Fw::LogLevel level, const std::string_view message)

--- a/src/framework/core/resourcemanager.cpp
+++ b/src/framework/core/resourcemanager.cpp
@@ -31,10 +31,6 @@
 #include "framework/platform/platform.h"
 #include "framework/util/crypt.h"
 
-#if ENABLE_ENCRYPTION == 1
-#include "client/game.h"
-#endif
-
 ResourceManager g_resources;
 
 void ResourceManager::init(const char* argv0)
@@ -241,23 +237,11 @@ std::string ResourceManager::readFileContents(const std::string& fileName)
     PHYSFS_close(file);
 
 #if ENABLE_ENCRYPTION == 1
-    const auto headerSize = std::string(ENCRYPTION_HEADER).size();
-    const bool hasHeader = (buffer.size() >= headerSize &&
-                            buffer.compare(0, headerSize, ENCRYPTION_HEADER) == 0);
-
-    if (hasHeader) {
-        buffer = buffer.substr(headerSize);
+    const std::string encHeader(ENCRYPTION_HEADER);
+    if (buffer.size() >= encHeader.size() &&
+        buffer.compare(0, encHeader.size(), encHeader) == 0) {
+        buffer = buffer.substr(encHeader.size());
         buffer = decrypt(buffer);
-    } else {
-        std::string path = fullPath;
-        std::replace(path.begin(), path.end(), '\\', '/');
-        if (path.compare(0, 5, std::string(AY_OBFUSCATE("/bot/"))) == 0) {
-            if (g_game.getFeature(Otc::GameAllowCustomBotScripts)) {
-                return buffer;
-            }
-            return "";
-        }
-        buffer = "";
     }
 #endif
 
@@ -308,13 +292,7 @@ bool ResourceManager::writeFileStream(const std::string& fileName, std::iostream
 
 bool ResourceManager::writeFileContents(const std::string& fileName, const std::string& data)
 {
-#if ENABLE_ENCRYPTION == 1
-    std::string encryptedData = encrypt(data, std::string(ENCRYPTION_PASSWORD));
-    std::string finalData = std::string(ENCRYPTION_HEADER) + encryptedData;
-    return writeFileBuffer(fileName, (const uint8_t*)finalData.c_str(), finalData.size());
-#else
     return writeFileBuffer(fileName, (const uint8_t*)data.c_str(), data.size());
-#endif
 }
 
 FileStreamPtr ResourceManager::openFile(const std::string& fileName)


### PR DESCRIPTION
## Summary
- **readFileContents()** crashes on startup by accessing `g_game.getFeature()` before `g_game` is constructed — removed the dependency; non-encrypted files now pass through instead of returning empty string
- **writeFileContents()** encrypts ALL writes (including user configs), corrupting them on restart — removed runtime encryption; only `--encrypt` builder should encrypt
- **FileStream::cache()** decrypts unconditionally (even without header) and uses `std::memcmp` instead of `std::memcpy` — now only decrypts when header is present, using in-place decrypt
- **logger.cpp** silences all logs when encryption is enabled — removed the conditional

## Test plan
- [x] Build with `ENABLE_ENCRYPTION=0` — no behavior change
- [x] Build with `ENABLE_ENCRYPTION=1` + `ENABLE_ENCRYPTION_BUILDER=1`, run `--encrypt` on a copy of `data/`, `modules/`, `mods/`, `init.lua`
- [x] Rebuild with `ENABLE_ENCRYPTION=1` + `ENABLE_ENCRYPTION_BUILDER=0` (final exe)
- [x] Run from encrypted assets — client loads and runs normally
- [x] Run from non-encrypted assets — client loads and runs normally (passthrough)
- [x] Verify user configs (config.otml) are saved as plaintext and survive restart