### PR TITLE
fix: handle countWindow state to prevent multiple instances in item stash

### DIFF
--- a/modules/game_interface/gameinterface.lua
+++ b/modules/game_interface/gameinterface.lua
@@ -1573,8 +1573,12 @@ function stashItem(item)
             item:getStackPos(), 0)
         return
     end
-    if countWindow and not countWindow:isDestroyed() then
-        return
+    if countWindow then
+        if countWindow:isDestroyed() then
+            countWindow = nil
+        else
+            return
+        end
     end
     countWindow = g_ui.createWidget('CountStashWindow', rootWidget)
 

--- a/modules/game_interface/gameinterface.lua
+++ b/modules/game_interface/gameinterface.lua
@@ -1555,6 +1555,7 @@ local function handleItemInteraction(item, widget, callback)
     local cancelButton = widget:getChildById('buttonCancel')
     local cancelFunc = function()
         cancelButton:getParent():destroy()
+        countWindow = nil
         widget = nil
     end
 
@@ -1572,6 +1573,9 @@ function stashItem(item)
             item:getStackPos(), 0)
         return
     end
+    if countWindow and not countWindow:isDestroyed() then
+        return
+    end
     countWindow = g_ui.createWidget('CountStashWindow', rootWidget)
 
     handleItemInteraction(item, countWindow, function(amount)
@@ -1583,7 +1587,11 @@ end
 
 function moveStackableItem(item, toPos)
     if countWindow then
-        return
+        if countWindow:isDestroyed() then
+            countWindow = nil
+        else
+            return
+        end
     end
     if g_keyboard.isShiftPressed() then
         g_game.move(item, toPos, 1)


### PR DESCRIPTION
# Description

The problem occurs when using the item count screen. Canceling the screen prevents the widget from being destroyed, making it impossible to move items in the backpack. This requires the user to log in and log out again to clear this "residual data" and restore functionality. However, if the user cancels the count screen, the problem returns. When the user accepts the message, the widget is destroyed and functions normally.

The proposal is to clear the window's memory, allowing it to function perfectly during cancellation actions, without affecting players and without requiring them to log in again to fix the problem.

## Behavior

### **Actual**

- Canceling the item count dialog fails to destroy the widget in the background.
- The UI becomes locked for further item movements (drag-and-drop) in the backpack.
- The player is forced to relog to clear the residual data and restore functionality.

### **Expected**

- Canceling the item count dialog (via UI button or ESC key) properly clears the widget state and memory.
- The player can immediately resume moving items in the backpack without the need to relog.

## Fixes

Similar symptom to: #1562 

Difference: Issue #1562  appears to be caused by drag/drop mechanics. This current PR/Issue addresses a memory clear failure (residual state leak) specifically triggered by the item count screen cancellation.

## Type of change

Please delete options that are not relevant.

  - [x] Bug fix (non-breaking change which fixes an issue)
  - [ ] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [ ] This change requires a documentation update

## How Has This Been Tested

For both cases, after performing the action, try dragging another stackable item from your backpack, such as runes or potions. It's important to have at least two items for the window to activate.

- [ ] Move a stackable item and click cancel
- [ ] Move a stackable item and use the "ESC" key

**Test Configuration**:

  - Server Version: Canary 3.0
  - Client: 15.00
  - Operating System: Windows

## Checklist

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [x] I checked the PR checks reports
  - [ ] I have commented my code, particularly in hard-to-understand areas
  - [ ] I have made corresponding changes to the documentation
  - [x] My changes generate no new warnings
  - [ ] I have added tests that prove my fix is effective or that my feature works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an issue where multiple overlapping count dialogs could appear simultaneously during inventory management operations with stackable items, ensuring only a single dialog displays at any given time.
  * Enhanced UI state management to properly clear and reset interface elements when users cancel item interactions, preventing residual UI artifacts and maintaining a clean interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->