### PR TITLE
fix(vbot): extend findItem helper to search all equipped inventory slots

### DIFF
--- a/mods/game_bot/functions/player.lua
+++ b/mods/game_bot/functions/player.lua
@@ -159,9 +159,13 @@ context.findItem = function(itemId, subType)
   if subType == nil then
     subType = -1
   end
-  local ammo = context.player:getInventoryItem(InventorySlotAmmo)
-  if ammo and ammo:getId() == itemId and (subType == -1 or ammo:getSubType() == subType) then
-    return ammo
+  -- Search every equipped inventory slot (helmet, amulet, backpack, armor,
+  -- weapons, legs, boots, ring and ammo) before falling back to containers.
+  for slot = InventorySlotFirst, InventorySlotLast do
+    local item = context.player:getInventoryItem(slot)
+    if item and item:getId() == itemId and (subType == -1 or item:getSubType() == subType) then
+      return item
+    end
   end
   return g_game.findItemInContainers(itemId, subType)
 end

--- a/mods/game_bot/functions/player.lua
+++ b/mods/game_bot/functions/player.lua
@@ -155,19 +155,11 @@ context.useRune = function(itemid, target, lastSpellTimeout)
 end
 context.userune = context.useRune
 
-context.findItem = function(itemId, subType)
-  if subType == nil then
-    subType = -1
-  end
-  -- Search every equipped inventory slot (helmet, amulet, backpack, armor,
-  -- weapons, legs, boots, ring and ammo) before falling back to containers.
-  for slot = InventorySlotFirst, InventorySlotLast do
-    local item = context.player:getInventoryItem(slot)
-    if item and item:getId() == itemId and (subType == -1 or item:getSubType() == subType) then
-      return item
-    end
-  end
-  return g_game.findItemInContainers(itemId, subType)
+context.findItem = function(itemId, subType, tier)
+  -- Delegate to the canonical helper so the bot shares the same inventory
+  -- traversal order as the rest of the client (equipped slots from HEAD to
+  -- AMMO, then open containers) and inherits its tier support.
+  return g_game.findPlayerItem(itemId, subType or -1, tier)
 end
 
 context.attack = g_game.attack


### PR DESCRIPTION
## Summary
- Widen `context.findItem` in `mods/game_bot/functions/player.lua` so it searches every equipped inventory slot (`InventorySlotFirst..InventorySlotLast`) before falling back to `g_game.findItemInContainers`, delegating to the canonical `g_game.findPlayerItem` helper already defined at `modules/gamelib/game.lua` so the bot shares a single source of truth with corelib, hotkeys and the base client.

## Motivation
Today `context.findItem` only checks `InventorySlotAmmo` before the containers fallback, so bot scripts that look for items worn on other slots (helmet, amulet, backpack, armor, weapons, legs, boots, ring) receive `nil` even when the item is equipped on the player. This is inconsistent with the name of the helper and surprises scripts that cannot be sure whether an item lives in a container or in a slot (for example, hotkey managers that swap an amulet in and out, or scripts that toggle rings).

This is especially relevant for servers running older protocols where slot-type enforcement was looser: on legacy Tibia clients it was possible to hold arbitrary items in the hand slots (e.g. a potion, rune or tool) and many OTs preserve that behaviour. With the current helper those items are invisible to `findItem` unless they happen to be inside a container, which breaks scripts that expect to locate what the player is holding.

## Behavioural change
`findItem` now returns the first match in slot order (`HEAD`, `NECK`, `BACK`, `BODY`, `RIGHT`, `LEFT`, `LEGS`, `FEET`, `FINGER`, `AMMO`) and only then consults open containers. Previously only `AMMO` and containers were consulted, in that order. Scripts that relied on `findItem(ammoId)` never returning the wielded stack when the same id was also present in another slot should be reviewed; this is expected to affect very few callers because the old helper only scanned `AMMO` anyway and because the equipped-first ordering matches the client's own `findPlayerItem` helper.

## References
Inspired by an equivalent change in OTAcademy/otclientv8:
- `d754f3e` — findItem api search ammo slot (PR [OTAcademy/otclientv8#86](https://github.com/OTAcademy/otclientv8/pull/86))

That fork reimplemented the traversal inline. After review feedback this PR was retargeted to call the pre-existing `g_game.findPlayerItem` instead, which already performs the same slot loop plus the containers fallback and transparently supports the optional `tier` parameter used by later protocols.

## Validation
The change is a small delegation of a single helper with no caller signature change (a new optional `tier` parameter is accepted and forwarded). Correctness was verified by code inspection:

- [x] `findItem(<amuletId>)` now returns the item when equipped on the neck slot; previously returned `nil`.
- [x] `findItem(<ammoId>)` still returns the ammo when equipped on slot 10 (`InventorySlotAmmo == InventorySlotLast`).
- [x] `findItem(<potionId>)` locates a potion held on `InventorySlotLeft` / `InventorySlotRight`, which is valid on legacy protocols where the hand slots accept arbitrary item types.
- [x] When the target item is only inside a container, the slot loop finds nothing and control falls through to the unchanged containers scan.
- [x] `subType` filter is preserved and applied uniformly across every slot, matching the previous ammo-only check.
- [x] The optional `tier` parameter now transparently reaches `g_game.findItemInContainers`, matching the signature already honoured by `corelib/keybind.lua` and `modules/game_hotkeys/hotkeys_manager.lua`.