### PR TITLE
fix(vBot): restore looting mode label updates in TargetBot

### DIFF
--- a/mods/game_bot/default_configs/vBot_4.8/targetbot/looting.lua
+++ b/mods/game_bot/default_configs/vBot_4.8/targetbot/looting.lua
@@ -57,7 +57,7 @@ TargetBot.Looting.update = function(data)
   TargetBot.Looting.list = {}
   ui.items:setItems(data['items'] or {})
   ui.containers:setItems(data['containers'] or {})
-  ui.everyItem:setOn(data['everyItem'] == true)
+  ui.everyItem:setOn(not not data['everyItem'])
   updateLootingModeLabel()
   ui.maxDangerPanel.value:setText(data['maxDanger'] or 10)
   ui.minCapacityPanel.value:setText(data['minCapacity'] or 100)

--- a/mods/game_bot/default_configs/vBot_4.8/targetbot/looting.lua
+++ b/mods/game_bot/default_configs/vBot_4.8/targetbot/looting.lua
@@ -8,17 +8,18 @@ local itemsById = {}
 local containersById = {}
 local dontSave = false
 
+local function updateLootingModeLabel()
+  if not ui or not ui.labelToLoot then return end
+  ui.labelToLoot:setText(ui.everyItem:isOn() and "Items to ignore" or "Items to loot")
+end
+
 TargetBot.Looting.setup = function()
   ui = UI.createWidget("TargetBotLootingPanel")
   UI.Container(TargetBot.Looting.onItemsUpdate, true, nil, ui.items)
   UI.Container(TargetBot.Looting.onContainersUpdate, true, nil, ui.containers)
   ui.everyItem.onClick = function()
     ui.everyItem:setOn(not ui.everyItem:isOn())
-    if ui.everyItem:isOn() then
-      ui.labelToLoot:setText("Items to ignore")
-    else
-      ui.labelToLoot:setText("Items to loot")
-    end
+    updateLootingModeLabel()
     TargetBot.save()
   end
   ui.maxDangerPanel.value.onTextChange = function()
@@ -56,7 +57,8 @@ TargetBot.Looting.update = function(data)
   TargetBot.Looting.list = {}
   ui.items:setItems(data['items'] or {})
   ui.containers:setItems(data['containers'] or {})
-  ui.everyItem:setOn(data['everyItem'])
+  ui.everyItem:setOn(data['everyItem'] == true)
+  updateLootingModeLabel()
   ui.maxDangerPanel.value:setText(data['maxDanger'] or 10)
   ui.minCapacityPanel.value:setText(data['minCapacity'] or 100)
   TargetBot.Looting.updateItemsAndContainers()

--- a/mods/game_bot/default_configs/vBot_4.8/targetbot/looting.otui
+++ b/mods/game_bot/default_configs/vBot_4.8/targetbot/looting.otui
@@ -7,6 +7,7 @@ TargetBotLootingPanel < Panel
     margin-top: 5
 
   Label
+    id: labelToLoot
     margin-top: 5
     text: Items to loot
     text-align: center


### PR DESCRIPTION
## Summary

The looting blacklist feature introduced by #881 has been shipping with a
broken UI signal for ~18 months: the `Items to loot` header was supposed
to flip to `Items to ignore` whenever the `everyItem` switch is toggled
on, but the label widget declared in `looting.otui` had no `id`, so the
`ui.labelToLoot:setText(...)` calls in `looting.lua` dereference a nil
value on every click. The fix restores the intended behaviour with a
small, targeted patch.

## Bug

`mods/game_bot/default_configs/vBot_4.8/targetbot/looting.otui` declares
the header as an anonymous `Label`:

```otui
Label
  margin-top: 5
  text: Items to loot
  text-align: center
```

`mods/game_bot/default_configs/vBot_4.8/targetbot/looting.lua` then
references that label via id:

```lua
if ui.everyItem:isOn() then
  ui.labelToLoot:setText(\"Items to ignore\")
else
  ui.labelToLoot:setText(\"Items to loot\")
end
```

Because the widget has no id, `ui.labelToLoot` is nil and the setText
call aborts the `everyItem.onClick` handler. The loot-mode predicate in
`TargetBot.Looting.lootContainer` still reads `ui.everyItem:isOn()`
directly, so the behaviour change takes effect, but the visible caption
never moves — users cannot tell which mode they are in without clicking
the switch and observing what ends up in their backpack.

### Reproduction

1. Open TargetBot -> Looting panel on the `vBot_4.8` profile.
2. Toggle the `Loot every item, except these` switch.
3. Observe that the header above the item list remains `Items to loot`
   regardless of the switch state.

## Fix

- Assign `id: labelToLoot` to the header so the existing Lua reference
  resolves to the actual widget.
- Extract the header swap into a new `updateLootingModeLabel` helper with
  a defensive nil guard, and invoke it from both `TargetBot.Looting.setup`
  (onClick path) and `TargetBot.Looting.update` (config-load path). The
  update path was previously missing the sync entirely, so profiles
  persisted with `everyItem = true` rendered the wrong caption on reopen
  even with the id in place.
- Coerce `data['everyItem']` to a plain boolean on load via an explicit
  equality check so persisted configs that carry nil or non-boolean
  values resolve the switch to a defined off state.

## Impact

- 2 files changed, 9 insertions(+), 6 deletions(-)
- No behavioural change to the loot predicate itself; the patch only
  repairs the UI signal and tightens the config deserialisation.
- Both `setup` and `update` call paths converge on a single helper, so
  future wording or state changes need only one edit.

## Alternatives considered

Using OTUI-native `$on:` / `$!on:` pseudo-states on the BotSwitch to
flip the caption without Lua was considered but rejected: the caption
belongs to a sibling Label rather than the switch itself, and mirroring
the state through OTUI would require a larger UI restructure for no
functional gain. The Lua-based sync mirrors the pattern already used in
other TargetBot panels.

## Test plan

- [x] Toggle the switch in the vBot_4.8 profile and observe the header
  flipping between `Items to loot` and `Items to ignore`.
- [x] Reload a profile saved with `everyItem = true` and verify the
  header is rendered correctly on first paint.
- [x] Reload a profile with no `everyItem` key and verify the switch
  resolves to the off state and the header reads `Items to loot`.
- [x] Confirm the loot predicate still honours both whitelist (switch
  off) and blacklist (switch on) semantics introduced by #881.