### PR TITLE
fix: load assets hash identifier from assets.json.sha256

### DIFF
--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -603,7 +603,7 @@ void Game::loginWorld(const std::string_view account, const std::string_view pas
     if (!recordTo.empty()) {
         m_protocolGame->setRecorder(std::make_shared<PacketRecorder>(recordTo));
     }
-    m_protocolGame->login(account, password, worldHost, static_cast<uint16_t>(worldPort), characterName, authenticatorToken, sessionKey);
+    m_protocolGame->login(account, password, worldHost, static_cast<uint16_t>(worldPort), characterName, authenticatorToken, sessionKey, worldName);
     m_characterName = characterName;
     m_worldName = worldName;
 }

--- a/src/client/protocolgame.cpp
+++ b/src/client/protocolgame.cpp
@@ -25,7 +25,7 @@
 #include "protocolgame.h"
 
 void ProtocolGame::login(const std::string_view accountName, const std::string_view accountPassword, const std::string_view host, uint16_t port,
-                         const std::string_view characterName, const std::string_view authenticatorToken, const std::string_view sessionKey)
+                         const std::string_view characterName, const std::string_view authenticatorToken, const std::string_view sessionKey, std::string_view worldName)
 {
     m_accountName = accountName;
     m_accountPassword = accountPassword;
@@ -34,7 +34,7 @@ void ProtocolGame::login(const std::string_view accountName, const std::string_v
     m_characterName = characterName;
 
 #ifndef __EMSCRIPTEN__
-    connect(host, port);
+    connect(host, port, worldName);
 #else
     if (port == 7172)
         port = 443;

--- a/src/client/protocolgame.h
+++ b/src/client/protocolgame.h
@@ -29,7 +29,7 @@
 class ProtocolGame final : public Protocol
 {
 public:
-    void login(std::string_view accountName, std::string_view accountPassword, std::string_view host, uint16_t port, std::string_view characterName, std::string_view authenticatorToken, std::string_view sessionKey);
+    void login(std::string_view accountName, std::string_view accountPassword, std::string_view host, uint16_t port, std::string_view characterName, std::string_view authenticatorToken, std::string_view sessionKey, std::string_view worldName);
 
     void sendExtendedOpcode(uint8_t opcode, const std::string& buffer);
     void sendLoginPacket(uint32_t challengeTimestamp, uint8_t challengeRandom);

--- a/src/client/protocolgamesend.cpp
+++ b/src/client/protocolgamesend.cpp
@@ -59,7 +59,7 @@ void ProtocolGame::sendLoginPacket(const uint32_t challengeTimestamp, const uint
     }
 
     if (g_game.getClientVersion() >= 1334) {
-        msg->addString("appearancesHash");
+        msg->addString(g_things.getAssetIdentifier());
     } else if (g_game.getFeature(Otc::GameContentRevision)) {
         msg->addU16(g_things.getContentRevision());
     }

--- a/src/client/thingtypemanager.cpp
+++ b/src/client/thingtypemanager.cpp
@@ -148,6 +148,13 @@ bool ThingTypeManager::loadAppearances(const std::string& file)
 {
 #ifdef FRAMEWORK_PROTOBUF
     try {
+        const std::string assetIdentifierFilePath = g_resources.resolvePath(g_resources.guessFilePath(file + "assets", "json.sha256"));
+        std::ifstream assetIdentifierFile(assetIdentifierFilePath);
+        m_assetIdentifier = "";
+        if (!(assetIdentifierFile && std::getline(assetIdentifierFile, m_assetIdentifier))) {
+            m_assetIdentifier = "AssetIdentifier";
+        }
+
         if (!g_game.getFeature(Otc::GameLoadSprInsteadProtobuf)) {
             g_spriteAppearances.unload();
             int spritesCount = 0;

--- a/src/client/thingtypemanager.h
+++ b/src/client/thingtypemanager.h
@@ -74,6 +74,7 @@ public:
 
     uint32_t getDatSignature() { return m_datSignature; }
     uint16_t getContentRevision() { return m_contentRevision; }
+    const std::string& getAssetIdentifier() { return m_assetIdentifier; }
 
     bool isDatLoaded() { return m_datLoaded; }
     bool isValidDatId(const uint16_t id, const ThingCategory category) const { return category < ThingLastCategory && id >= 1 && id < m_thingTypes[category].size(); }
@@ -88,6 +89,7 @@ private:
 
     uint32_t m_datSignature{ 0 };
     uint16_t m_contentRevision{ 0 };
+    std::string m_assetIdentifier;
 
 #ifdef FRAMEWORK_EDITOR
     ItemTypePtr m_nullItemType;

--- a/src/framework/net/inputmessage.h
+++ b/src/framework/net/inputmessage.h
@@ -98,6 +98,26 @@ public:
         return data;
     }
 
+    void addCompressionFooter()
+    {
+        // Pointer to last 4 bytes of current buffer
+        const uint8_t* src = m_buffer + m_messageSize - 4;
+
+        // Optional: check if already equal to footer (avoid duplicating)
+        if (src[0] == 0x00 && src[1] == 0x00 && src[2] == 0xFF && src[3] == 0xFF)
+            return;
+
+        checkWrite(4);
+
+        static const uint8_t footer[] = { 0x00, 0x00, 0xFF, 0xFF }; // real tibia zlib tail
+        uint8_t* dest = m_buffer + m_messageSize;
+
+        // Copy last 4 bytes
+        std::memcpy(dest, footer, 4);
+
+        m_messageSize += 4;
+    }
+
 protected:
     void reset();
     void fillBuffer(const uint8_t* buffer, uint16_t size);

--- a/src/framework/net/inputmessage.h
+++ b/src/framework/net/inputmessage.h
@@ -109,7 +109,7 @@ public:
 
         checkWrite(4);
 
-        static const uint8_t footer[] = { 0x00, 0x00, 0xFF, 0xFF }; // real tibia zlib tail
+        static const uint8_t footer[] = { 0x00, 0x00, 0xFF, 0xFF };
         uint8_t* dest = m_buffer + m_messageSize;
 
         // Copy last 4 bytes

--- a/src/framework/net/protocol.cpp
+++ b/src/framework/net/protocol.cpp
@@ -51,7 +51,7 @@ Protocol::~Protocol()
 }
 
 #ifndef __EMSCRIPTEN__
-void Protocol::connect(const std::string_view host, const uint16_t port)
+void Protocol::connect(const std::string_view host, const uint16_t port, std::string_view worldName)
 {
     if (host == "proxy" || host == "0.0.0.0" || (host == "127.0.0.1" && g_proxy.isActive())) {
         m_disconnected = false;
@@ -72,9 +72,15 @@ void Protocol::connect(const std::string_view host, const uint16_t port)
             self->onError(std::forward<decltype(err)>(err));
         }
     });
-    m_connection->connect(host, port, [weakSelf] {
+    m_connection->connect(host, port, [weakSelf, worldName] {
         if (auto self = weakSelf.lock()) {
             if (!self->m_disconnected) {
+                if (g_game.getClientVersion() >= 1200) {
+                    std::string sendWorldName(worldName);
+                    sendWorldName += '\n';
+                    self->m_connection->write((const uint8_t*) sendWorldName.data(), sendWorldName.size());
+                    self->enabledSequencedPackets();
+                }
                 self->onConnect();
             }
         }
@@ -253,7 +259,11 @@ void Protocol::internalRecvData(const uint8_t* buffer, const uint16_t size)
         }
     }
 
+
+
     if (decompress) {
+        m_inputMessage->addCompressionFooter();
+
         static uint8_t zbuffer[InputMessage::BUFFER_MAXSIZE];
 
         m_zstream.next_in = m_inputMessage->getDataBuffer();
@@ -261,14 +271,13 @@ void Protocol::internalRecvData(const uint8_t* buffer, const uint16_t size)
         m_zstream.avail_in = m_inputMessage->getUnreadSize();
         m_zstream.avail_out = InputMessage::BUFFER_MAXSIZE;
 
-        const int32_t ret = inflate(&m_zstream, Z_FINISH);
+        const int32_t ret = inflate(&m_zstream, Z_SYNC_FLUSH);
         if (ret != Z_OK && ret != Z_STREAM_END) {
             g_logger.traceError("failed to decompress message - {}", m_zstream.msg);
             return;
         }
 
         const uint32_t totalSize = m_zstream.total_out;
-        inflateReset(&m_zstream);
         if (totalSize == 0) {
             g_logger.traceError("invalid size of decompressed message - %i", totalSize);
             return;

--- a/src/framework/net/protocol.h
+++ b/src/framework/net/protocol.h
@@ -33,7 +33,7 @@ public:
     ~Protocol() override;
 
 #ifndef __EMSCRIPTEN__
-    void connect(std::string_view host, uint16_t port);
+    void connect(std::string_view host, uint16_t port, std::string_view worldName);
 #else
     void connect(const std::string_view host, uint16_t port, bool gameWorld = false);
 #endif


### PR DESCRIPTION
# Description

The client should load asset hash identifier from file called assets.json.sha256. In "normal" client it's in the root folder. In OTC it can be loaded from same folder as assets are to keep multi-assets support.

## Behavior

### **Actual**

Client just send constant string called "assetIdentifier" which is useless for the server.

### **Expected**

Client should send proper asset identifier.

## Fixes

\# (issue)

## Type of change

Please delete options that are not relevant.

  - [x] Bug fix (non-breaking change which fixes an issue)
  - [x] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [ ] This change requires a documentation update

## How Has This Been Tested

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

  - [x] Tested and connected to Gunzodus server, server accepted provided hash identifier

**Test Configuration**:

  - Server Version: 15.11
  - Client: 15.11
  - Operating System: Win

## Checklist

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [x] I checked the PR checks reports
  - [x] I have commented my code, particularly in hard-to-understand areas
  - [ ] I have made corresponding changes to the documentation
  - [ ] My changes generate no new warnings
  - [x] I have added tests that prove my fix is effective or that my feature works
