### PR TITLE
fix: load and send asset hash identifier from assets.json.sha256

### DIFF
--- a/src/client/protocolgamesend.cpp
+++ b/src/client/protocolgamesend.cpp
@@ -59,7 +59,7 @@ void ProtocolGame::sendLoginPacket(const uint32_t challengeTimestamp, const uint
     }
 
     if (g_game.getClientVersion() >= 1334) {
-        msg->addString("appearancesHash");
+        msg->addString(g_things.getAssetIdentifier());
     } else if (g_game.getFeature(Otc::GameContentRevision)) {
         msg->addU16(g_things.getContentRevision());
     }

--- a/src/client/thingtypemanager.cpp
+++ b/src/client/thingtypemanager.cpp
@@ -148,6 +148,13 @@ bool ThingTypeManager::loadAppearances(const std::string& file)
 {
 #ifdef FRAMEWORK_PROTOBUF
     try {
+        const std::string assetIdentifierFilePath = g_resources.resolvePath(g_resources.guessFilePath(file + "assets", "json.sha256"));
+        std::ifstream assetIdentifierFile(assetIdentifierFilePath);
+        m_assetIdentifier = "";
+        if (!(assetIdentifierFile && std::getline(assetIdentifierFile, m_assetIdentifier))) {
+            m_assetIdentifier = "AssetIdentifier";
+        }
+
         if (!g_game.getFeature(Otc::GameLoadSprInsteadProtobuf)) {
             g_spriteAppearances.unload();
             int spritesCount = 0;

--- a/src/client/thingtypemanager.cpp
+++ b/src/client/thingtypemanager.cpp
@@ -148,11 +148,11 @@ bool ThingTypeManager::loadAppearances(const std::string& file)
 {
 #ifdef FRAMEWORK_PROTOBUF
     try {
-        const std::string assetIdentifierFilePath = g_resources.resolvePath(g_resources.guessFilePath(file + "assets", "json.sha256"));
-        std::ifstream assetIdentifierFile(assetIdentifierFilePath);
-        m_assetIdentifier = "";
-        if (!(assetIdentifierFile && std::getline(assetIdentifierFile, m_assetIdentifier))) {
-            m_assetIdentifier = "AssetIdentifier";
+        try {
+            m_assetIdentifier = g_resources.readFileContents(g_resources.resolvePath(g_resources.guessFilePath(file + "assets", "json.sha256")));
+        } catch (const std::exception& e) {
+            m_assetIdentifier = "AssetIdentifierUnknown";
+            g_logger.warning("Cannot load asset hash identifier from assets.json.sha256: {}", e.what());
         }
 
         if (!g_game.getFeature(Otc::GameLoadSprInsteadProtobuf)) {

--- a/src/client/thingtypemanager.cpp
+++ b/src/client/thingtypemanager.cpp
@@ -151,7 +151,7 @@ bool ThingTypeManager::loadAppearances(const std::string& file)
         try {
             m_assetIdentifier = g_resources.readFileContents(g_resources.resolvePath(g_resources.guessFilePath(file + "assets", "json.sha256")));
         } catch (const std::exception& e) {
-            m_assetIdentifier = "AssetIdentifierUnknown";
+            m_assetIdentifier = "appearancesHash";
             g_logger.warning("Cannot load asset hash identifier from assets.json.sha256: {}", e.what());
         }
 

--- a/src/client/thingtypemanager.h
+++ b/src/client/thingtypemanager.h
@@ -74,6 +74,7 @@ public:
 
     uint32_t getDatSignature() { return m_datSignature; }
     uint16_t getContentRevision() { return m_contentRevision; }
+    const std::string& getAssetIdentifier() { return m_assetIdentifier; }
 
     bool isDatLoaded() { return m_datLoaded; }
     bool isValidDatId(const uint16_t id, const ThingCategory category) const { return category < ThingLastCategory && id >= 1 && id < m_thingTypes[category].size(); }
@@ -88,6 +89,7 @@ private:
 
     uint32_t m_datSignature{ 0 };
     uint16_t m_contentRevision{ 0 };
+    std::string m_assetIdentifier;
 
 #ifdef FRAMEWORK_EDITOR
     ItemTypePtr m_nullItemType;


### PR DESCRIPTION
# Description

The client should load asset hash identifier from file called assets.json.sha256. In "normal" client it's in the root folder. In OTC it can be loaded from same folder as assets to keep multi-assets support.

## Behavior

### **Actual**

Client just send constant string called "appearancesHash" which is useless for the server.

### **Expected**

Client should send proper asset identifier.

## Fixes

\# (issue)

## Type of change

Please delete options that are not relevant.

  - [x] Bug fix (non-breaking change which fixes an issue)
  - [x] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [ ] This change requires a documentation update

## How Has This Been Tested

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

  - [x] Tested and connected to Gunzodus server, server accepted provided hash identifier

**Test Configuration**:

  - Server Version: 15.11
  - Client: 15.11
  - Operating System: Win

## Checklist

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [x] I checked the PR checks reports
  - [x] I have commented my code, particularly in hard-to-understand areas
  - [ ] I have made corresponding changes to the documentation
  - [ ] My changes generate no new warnings
  - [x] I have added tests that prove my fix is effective or that my feature works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Enhanced the login authentication process with dynamic asset validation that detects and verifies game resources in real-time instead of relying on static predetermined values.
* Implemented robust error handling mechanisms with automatic fallback support to ensure stable connections when asset detection encounters unexpected issues or operational failures, improving overall system reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->